### PR TITLE
Add ethernet setup process

### DIFF
--- a/boards/raspberrypi/rpi_5/rpi_5_defconfig
+++ b/boards/raspberrypi/rpi_5/rpi_5_defconfig
@@ -21,3 +21,6 @@ CONFIG_ENTROPY_GENERATOR=y
 
 # TODO: Find an appopriate random generator, since this casues a warning.
 CONFIG_TEST_RANDOM_GENERATOR=y
+
+CONFIG_POSIX_THREADS=y
+CONFIG_POSIX_SPIN_LOCKS=y

--- a/drivers/dma/dma_tsn_nic.c
+++ b/drivers/dma/dma_tsn_nic.c
@@ -197,7 +197,7 @@ static int get_engine_id(struct dma_tsn_nic_engine_regs *regs)
 static int engine_init_regs(struct dma_tsn_nic_engine_regs *regs)
 {
 	uint32_t align_bytes, granularity_bytes, address_bits;
-	uint32_t tmp;
+	uint32_t tmp, flags;
 
 	sys_write32(DMA_CTRL_NON_INCR_ADDR, (mem_addr_t)&regs->control_w1c);
 	tmp = sys_read32((mem_addr_t)&regs->alignments);
@@ -212,24 +212,17 @@ static int engine_init_regs(struct dma_tsn_nic_engine_regs *regs)
 		address_bits = 64;
 	}
 
-	tmp = DMA_CTRL_IE_DESC_ALIGN_MISMATCH;
-	tmp |= DMA_CTRL_IE_MAGIC_STOPPED;
-	tmp |= DMA_CTRL_IE_IDLE_STOPPED;
-	tmp |= DMA_CTRL_IE_READ_ERROR;
-	tmp |= DMA_CTRL_IE_DESC_ERROR;
-	tmp |= DMA_CTRL_IE_DESC_STOPPED;
-	tmp |= DMA_CTRL_IE_DESC_COMPLETED;
+	flags = (DMA_CTRL_IE_DESC_ALIGN_MISMATCH | DMA_CTRL_IE_MAGIC_STOPPED |
+		 DMA_CTRL_IE_IDLE_STOPPED | DMA_CTRL_IE_READ_ERROR | DMA_CTRL_IE_DESC_ERROR |
+		 DMA_CTRL_IE_DESC_STOPPED | DMA_CTRL_IE_DESC_COMPLETED);
 
-	sys_write32(tmp, (mem_addr_t)&regs->interrupt_enable_mask);
+	sys_write32(flags, (mem_addr_t)&regs->interrupt_enable_mask);
 
-	tmp = DMA_CTRL_RUN_STOP;
-	tmp |= DMA_CTRL_IE_READ_ERROR;
-	tmp |= DMA_CTRL_IE_DESC_ERROR;
-	tmp |= DMA_CTRL_IE_DESC_ALIGN_MISMATCH;
-	tmp |= DMA_CTRL_IE_MAGIC_STOPPED;
-	tmp |= DMA_CTRL_POLL_MODE_WB;
+	flags = (DMA_CTRL_RUN_STOP | DMA_CTRL_IE_READ_ERROR | DMA_CTRL_IE_DESC_ERROR |
+		 DMA_CTRL_IE_DESC_ALIGN_MISMATCH | DMA_CTRL_IE_MAGIC_STOPPED |
+		 DMA_CTRL_POLL_MODE_WB);
 
-	sys_write32(tmp, (mem_addr_t)&regs->control);
+	sys_write32(flags, (mem_addr_t)&regs->control);
 
 	return 0;
 }

--- a/drivers/ethernet/eth_tsn_nic.c
+++ b/drivers/ethernet/eth_tsn_nic.c
@@ -154,11 +154,10 @@ static void eth_tsn_nic_iface_init(struct net_if *iface)
 		data->iface = iface;
 	}
 
+	net_if_set_link_addr(iface, data->mac_addr, 6, NET_LINK_ETHERNET);
 	ethernet_init(iface);
 
 	ARG_UNUSED(config);
-
-	/* TODO: sw-238 (Setup) */
 }
 
 #if defined(CONFIG_NET_STATISTICS_ETHERNET)

--- a/drivers/ethernet/eth_tsn_nic.c
+++ b/drivers/ethernet/eth_tsn_nic.c
@@ -282,6 +282,7 @@ static int eth_tsn_nic_init(const struct device *dev)
 	pthread_spin_init(&data->tx_lock, PTHREAD_PROCESS_PRIVATE);
 	pthread_spin_init(&data->rx_lock, PTHREAD_PROCESS_PRIVATE);
 
+	/* TODO: Select proper values for the first three bytes */
 	gen_random_mac(data->mac_addr, 0x0, 0x0, 0xab);
 
 	printk("Ethernet init\n");

--- a/drivers/ethernet/eth_tsn_nic.c
+++ b/drivers/ethernet/eth_tsn_nic.c
@@ -46,6 +46,11 @@ LOG_MODULE_REGISTER(eth_tsn_nic, LOG_LEVEL_ERR);
 #define DMA_ENGINE_START 16268831
 #define DMA_ENGINE_STOP  16268830
 
+/* Temporary macros: need to be deleted later */
+#define RX_ENGINE_REG_ADDR 0x1b08001000
+#define RX_SGDMA_REG_ADDR 0x1b08005000
+#define RX_REGS_SIZE 0x1000
+
 struct dma_tsn_nic_engine_regs {
 	uint32_t identifier;
 	uint32_t control;
@@ -181,9 +186,6 @@ static int eth_tsn_nic_start(const struct device *dev)
 	 * TODO: Find out how to move this to dma driver
 	 * or how to access dma registers from here
 	 */
-#define RX_ENGINE_REG_ADDR 0x1b08001000
-#define RX_SGDMA_REG_ADDR 0x1b08005000
-#define RX_REGS_SIZE 0x1000
 	mm_reg_t rx_regs, rx_sgdma_regs;
 	device_map(&rx_regs, RX_ENGINE_REG_ADDR, RX_REGS_SIZE, K_MEM_CACHE_NONE);
 	device_map(&rx_sgdma_regs, RX_SGDMA_REG_ADDR, RX_REGS_SIZE, K_MEM_CACHE_NONE);

--- a/drivers/ethernet/eth_tsn_nic.c
+++ b/drivers/ethernet/eth_tsn_nic.c
@@ -181,9 +181,12 @@ static int eth_tsn_nic_start(const struct device *dev)
 	 * TODO: Find out how to move this to dma driver
 	 * or how to access dma registers from here
 	 */
+#define RX_ENGINE_REG_ADDR 0x1b08001000
+#define RX_SGDMA_REG_ADDR 0x1b08005000
+#define RX_REGS_SIZE 0x1000
 	mm_reg_t rx_regs, rx_sgdma_regs;
-	device_map(&rx_regs, 0x1b08001000, 0x1000, K_MEM_CACHE_NONE);
-	device_map(&rx_sgdma_regs, 0x1b08005000, 0x1000, K_MEM_CACHE_NONE);
+	device_map(&rx_regs, RX_ENGINE_REG_ADDR, RX_REGS_SIZE, K_MEM_CACHE_NONE);
+	device_map(&rx_sgdma_regs, RX_SGDMA_REG_ADDR, RX_REGS_SIZE, K_MEM_CACHE_NONE);
 
 	pthread_spin_lock(&data->rx_lock);
 

--- a/drivers/ethernet/eth_tsn_nic.c
+++ b/drivers/ethernet/eth_tsn_nic.c
@@ -30,7 +30,7 @@ LOG_MODULE_REGISTER(eth_tsn_nic, LOG_LEVEL_ERR);
 
 #include "eth.h"
 
-#define BUFFER_SIZE 1560
+#define BUFFER_SIZE (1500 + 60) /* Ethernet MTU + TSN Metadata */
 
 #define DESC_MAGIC 0xAD4B0000UL
 
@@ -290,7 +290,7 @@ static int eth_tsn_nic_init(const struct device *dev)
 
 	printk("Ethernet init\n");
 
-	eth_tsn_nic_start(dev); /* TODO: This is for test only: this should be called by user app */
+	eth_tsn_nic_start(dev); /* TODO: This is for test only: this is called by zephyr subsys */
 
 	/* Test logs */
 	/*


### PR DESCRIPTION
TSN NIC 드라이버의 이더넷 부분에 초기 설정 단계를 추가했습니다.

레지스터의 값들이 제대로 설정되는 것까지는 확인했지만, 이것으로 TSN NIC <-> RPi5 간 통신이 완벽히 준비가 된 것인지는 아직 확실하지 않습니다. 이는 Tx/Rx 작업 하면서 부족한 부분이 있으면 추가할 예정입니다.

이에 더해, 기존 Linux용 XDMA 드라이버는 DMA와 네트워크 부분이 사실상 분리되어 있지 않아 네트워크를 담당하는 부분에서 DMA 레지스터를 직접 조작하는 데에 문제가 없지만, Zephyr의 구조에 맞추어 이를 억지로 분리하다 보니 기존 구현을 사용하기 어려운 문제가 있습니다.

이를 단기간에 해결하기는 어려울 것으로 보여 지금은 기능적인 면에서 먼저 완성하는 것을 목표로 하고, 이를 다듬어 Zephyr 구조에 맞추는 것은 모든 기능이 구현된 후에 진행하려고 합니다.