### PR TITLE
Add Qav/Qbv prototype

### DIFF
--- a/drivers/ethernet/eth_tsn_nic_tsn.c
+++ b/drivers/ethernet/eth_tsn_nic_tsn.c
@@ -362,7 +362,7 @@ static bool get_timestamps(struct timestamps *timestamps, const struct tsn_confi
 		timestamps->from = from;
 		timestamps->to = TSN_ALWAYS_OPEN(timestamps->from);
 		/* delay_* is pointless. Just set it to be right next to the frame */
-		timestamps->delay_from = timestamps->from;
+		timestamps->delay_from = timestamps->to + 1;
 		timestamps->delay_to = TSN_ALWAYS_OPEN(timestamps->delay_from);
 		return true;
 	}
@@ -384,7 +384,7 @@ static bool get_timestamps(struct timestamps *timestamps, const struct tsn_confi
 		timestamps->from = from;
 		timestamps->to = TSN_ALWAYS_OPEN(timestamps->from);
 		if (consider_delay) {
-			timestamps->delay_from = timestamps->from;
+			timestamps->delay_from = timestamps->to + 1;
 			timestamps->delay_to = TSN_ALWAYS_OPEN(timestamps->delay_from);
 		}
 		return true;

--- a/drivers/ethernet/eth_tsn_nic_tsn.c
+++ b/drivers/ethernet/eth_tsn_nic_tsn.c
@@ -327,6 +327,7 @@ static bool get_timestamps(struct timestamps *timestamps, const struct tsn_confi
 	const struct qbv_baked_config *baked;
 	const struct qbv_baked_prio *baked_prio;
 	const struct qbv_config *qbv = &tsn_config->qbv;
+
 	memset(timestamps, 0, sizeof(struct timestamps));
 
 	if (qbv->enabled == false) {

--- a/drivers/ethernet/eth_tsn_nic_tsn.c
+++ b/drivers/ethernet/eth_tsn_nic_tsn.c
@@ -473,7 +473,7 @@ static void spend_qav_credit(struct tsn_config *tsn_config, net_time_t at, uint8
 		qav->credit = qav->lo_credit;
 	}
 
-	/* Calulate next available time */
+	/* Calculate next available time */
 	send_end = at + sending_duration;
 	qav->last_update = send_end;
 	if (qav->credit < 0) {


### PR DESCRIPTION
Qav와 Qbv의 프로토타입을 추가합니다.

적용 로직은 기존 드라이버에서 그대로 가져왔으며, QoS 설정 파라미터를 기존 리눅스 드라이버에서의 구현에 맞게 변환해 저장하는 정도만 새로 추가되었습니다.

테스트 결과, 기존 로직으로 Qbv가 정상적으로 작동하는 것을 확인했습니다. 다만 Qav의 경우 from, to 값으로는 직관적으로 확인이 어려워 아직 테스트는 되지 않은 상태입니다.

아래는 Cycle 1s (500ms open, 500ms close) 설정에서 50ms 간격으로 패킷을 전송하도록 했을 때 from 값들을 nanosecond 단위로 변환해 출력한 것입니다.

![image](https://github.com/user-attachments/assets/118e5ac3-6400-4af6-9364-732e5f2024ea)

Close SW-296
