### PR TITLE
fix(length of net_pkt_read): set alignment padding length after net_pkt_read

### DIFF
--- a/drivers/ethernet/eth_tsn_nic.c
+++ b/drivers/ethernet/eth_tsn_nic.c
@@ -275,13 +275,16 @@ static int eth_tsn_nic_send(const struct device *dev, struct net_pkt *pkt)
 
 	len = net_pkt_get_len(pkt);
 
+	// initialize the tx_buffer
 	memset(data->tx_buffer.data, 0, sizeof(data->tx_buffer.data));
 
+	// copy packet data with the original length to tx_buffer
 	ret = net_pkt_read(pkt, data->tx_buffer.data, len);
 	if (ret != 0) {
 		goto error;
 	}
 	
+	// padding alignment
 	if (len < ETH_ZLEN) {
 		len = ETH_ZLEN;
 	}	

--- a/drivers/ethernet/eth_tsn_nic.c
+++ b/drivers/ethernet/eth_tsn_nic.c
@@ -273,14 +273,17 @@ static int eth_tsn_nic_send(const struct device *dev, struct net_pkt *pkt)
 
 	pthread_spin_lock(&data->tx_lock);
 
-	len = net_pkt_get_len(pkt);
-	if (len < ETH_ZLEN) {
-		len = ETH_ZLEN;
-	}
+	memset(data->tx_buffer.data, 0, sizeof(data->tx_buffer.data));
+
 	ret = net_pkt_read(pkt, data->tx_buffer.data, len);
 	if (ret != 0) {
 		goto error;
 	}
+
+	len = net_pkt_get_len(pkt);
+	if (len < ETH_ZLEN) {
+		len = ETH_ZLEN;
+	}	
 
 	data->tx_buffer.metadata.frame_length = len;
 


### PR DESCRIPTION
**목적**
버그 수정

**중요 수정된 범위/파일**
eth_tsn_nic.c

**주요 변경 사항**
문제: net_pkt_read 가 -ENOBUF (-105) 발생
원인: 전송 packet 의 크기가 ETH_ZLEN(60) 보다 작은 경우 padding alignment 동작을 한 뒤에 net_pkt_read 동작을 하기 때문에 발생
해결:
1. net_pkt_read 동작 전에 버퍼 초기화
2. padding alignment 동작을 net_pkt_read 후로 순서 변경

**테스트**
UDP 전송 테스트 프로그램으로 시험

**추가 고려 사항**
eth_tsn_nic_send 함수의 DMA 전송 동작에서 halt 발생으로 packet 전송 되지 않음