### PR TITLE
fix(pcie-brcmstb): fix pcie device driver to load all ranges and regs…

### DIFF
--- a/drivers/ethernet/eth_tsn_nic.c
+++ b/drivers/ethernet/eth_tsn_nic.c
@@ -443,6 +443,7 @@ static int eth_tsn_nic_send(const struct device *dev, struct net_pkt *pkt)
 	LOG_DBG("Completed Desc Count: %d\n", completed);
 
 	uint32_t nCompleted = 0;
+
 	for (int i = 0; i < 100000; ++i) {
 		uint32_t completed = sys_read32((uintptr_t)data->regs[DMA_H2C] + 0x48);
 

--- a/drivers/ethernet/eth_tsn_nic.c
+++ b/drivers/ethernet/eth_tsn_nic.c
@@ -44,7 +44,7 @@ LOG_MODULE_REGISTER(eth_tsn_nic, LOG_LEVEL_DBG);
 #define TSN_REG_PULSE_AT_LO     0x0030
 #define TSN_REG_CYCLE_1S        0x0034
 
-#define TSN_REG_TEMAC_STATUS	0x0500
+#define TSN_REG_TEMAC_STATUS 0x0500
 
 static inline uint32_t fpga_reg_read(const struct device *dev, uint32_t offset)
 {
@@ -57,75 +57,75 @@ void tsn_print_top_registers(const struct device *dev)
 {
 	LOG_DBG(">>> TSN TOP Register Group <<<");
 	LOG_DBG("TSN_VERSION          (0x%04x): 0x%08x", TSN_REG_VERSION,
-			fpga_reg_read(dev, TSN_REG_VERSION));
+		fpga_reg_read(dev, TSN_REG_VERSION));
 	LOG_DBG("TSN_CONFIG           (0x%04x): 0x%08x", TSN_REG_CONFIG,
-			fpga_reg_read(dev, TSN_REG_CONFIG));		
+		fpga_reg_read(dev, TSN_REG_CONFIG));
 	LOG_DBG("TSN_CONTROL          (0x%04x): 0x%08x", TSN_REG_CONTROL,
-			fpga_reg_read(dev, TSN_REG_CONTROL));		
+		fpga_reg_read(dev, TSN_REG_CONTROL));
 	LOG_DBG("SCRATCH              (0x%04x): 0x%08x", TSN_REG_SCRATCH,
-			fpga_reg_read(dev, TSN_REG_SCRATCH));		
+		fpga_reg_read(dev, TSN_REG_SCRATCH));
 	LOG_DBG("QBV_SLOT_STATUS      (0x%04x): 0x%08x", TSN_REG_QBV_SLOT_STATUS,
-			fpga_reg_read(dev, TSN_REG_QBV_SLOT_STATUS));		
+		fpga_reg_read(dev, TSN_REG_QBV_SLOT_STATUS));
 	LOG_DBG("PULSE_AT_HI [63:32]  (0x%04x): 0x%08x", TSN_REG_PULSE_AT_HI,
-			fpga_reg_read(dev, TSN_REG_PULSE_AT_HI));		
+		fpga_reg_read(dev, TSN_REG_PULSE_AT_HI));
 	LOG_DBG("PULSE_AT_LO [31:0]   (0x%04x): 0x%08x", TSN_REG_PULSE_AT_LO,
-			fpga_reg_read(dev, TSN_REG_PULSE_AT_LO));		
+		fpga_reg_read(dev, TSN_REG_PULSE_AT_LO));
 	LOG_DBG("CYCLE_1S             (0x%04x): 0x%08x", TSN_REG_CYCLE_1S,
-			fpga_reg_read(dev, TSN_REG_CYCLE_1S));		
+		fpga_reg_read(dev, TSN_REG_CYCLE_1S));
 	LOG_DBG("TEMAC_STATUS         (0x%04x): 0x%08x", TSN_REG_TEMAC_STATUS,
-			fpga_reg_read(dev, TSN_REG_TEMAC_STATUS));				   
+		fpga_reg_read(dev, TSN_REG_TEMAC_STATUS));
 }
 
 void dump_dma_h2c_all_regs(struct dma_tsn_nic_engine_regs *regs)
 {
-    LOG_DBG("=== DMA Engine Registers ===");
+	LOG_DBG("=== DMA Engine Registers ===");
 
-    LOG_DBG("identifier              : 0x%08x", regs->identifier);
-    LOG_DBG("control                 : 0x%08x", regs->control);
-    LOG_DBG("control_w1s             : 0x%08x", regs->control_w1s);
-    LOG_DBG("control_w1c             : 0x%08x", regs->control_w1c);
+	LOG_DBG("identifier              : 0x%08x", regs->identifier);
+	LOG_DBG("control                 : 0x%08x", regs->control);
+	LOG_DBG("control_w1s             : 0x%08x", regs->control_w1s);
+	LOG_DBG("control_w1c             : 0x%08x", regs->control_w1c);
 
-    LOG_DBG("status                  : 0x%08x", regs->status);
-    LOG_DBG("status_rc               : 0x%08x", regs->status_rc);
-    LOG_DBG("completed_desc_count    : 0x%08x", regs->completed_desc_count);
-    LOG_DBG("alignments              : 0x%08x", regs->alignments);
+	LOG_DBG("status                  : 0x%08x", regs->status);
+	LOG_DBG("status_rc               : 0x%08x", regs->status_rc);
+	LOG_DBG("completed_desc_count    : 0x%08x", regs->completed_desc_count);
+	LOG_DBG("alignments              : 0x%08x", regs->alignments);
 
-    LOG_DBG("poll_mode_wb_lo         : 0x%08x", regs->poll_mode_wb_lo);
-    LOG_DBG("poll_mode_wb_hi         : 0x%08x", regs->poll_mode_wb_hi);
+	LOG_DBG("poll_mode_wb_lo         : 0x%08x", regs->poll_mode_wb_lo);
+	LOG_DBG("poll_mode_wb_hi         : 0x%08x", regs->poll_mode_wb_hi);
 
-    LOG_DBG("interrupt_enable_mask   : 0x%08x", regs->interrupt_enable_mask);
-    LOG_DBG("int_en_mask_w1s         : 0x%08x", regs->interrupt_enable_mask_w1s);
-    LOG_DBG("int_en_mask_w1c         : 0x%08x", regs->interrupt_enable_mask_w1c);
+	LOG_DBG("interrupt_enable_mask   : 0x%08x", regs->interrupt_enable_mask);
+	LOG_DBG("int_en_mask_w1s         : 0x%08x", regs->interrupt_enable_mask_w1s);
+	LOG_DBG("int_en_mask_w1c         : 0x%08x", regs->interrupt_enable_mask_w1c);
 
-    LOG_DBG("perf_ctrl               : 0x%08x", regs->perf_ctrl);
-    LOG_DBG("perf_cyc_lo             : 0x%08x", regs->perf_cyc_lo);
-    LOG_DBG("perf_cyc_hi             : 0x%08x", regs->perf_cyc_hi);
-    LOG_DBG("perf_dat_lo             : 0x%08x", regs->perf_dat_lo);
-    LOG_DBG("perf_dat_hi             : 0x%08x", regs->perf_dat_hi);
-    LOG_DBG("perf_pnd_lo             : 0x%08x", regs->perf_pnd_lo);
-    LOG_DBG("perf_pnd_hi             : 0x%08x", regs->perf_pnd_hi);
+	LOG_DBG("perf_ctrl               : 0x%08x", regs->perf_ctrl);
+	LOG_DBG("perf_cyc_lo             : 0x%08x", regs->perf_cyc_lo);
+	LOG_DBG("perf_cyc_hi             : 0x%08x", regs->perf_cyc_hi);
+	LOG_DBG("perf_dat_lo             : 0x%08x", regs->perf_dat_lo);
+	LOG_DBG("perf_dat_hi             : 0x%08x", regs->perf_dat_hi);
+	LOG_DBG("perf_pnd_lo             : 0x%08x", regs->perf_pnd_lo);
+	LOG_DBG("perf_pnd_hi             : 0x%08x", regs->perf_pnd_hi);
 
-    LOG_DBG("===========================");
+	LOG_DBG("===========================");
 }
 
 static void eth_tsn_check_status()
 {
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(pcie1), okay)
-   	LOG_DBG("PCIe controller is okay.");
+	LOG_DBG("PCIe controller is okay.");
 #else
 	LOG_ERR("PCIe controller is NOT okay.");
 #endif
 
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(eth), okay)
-    const struct device *eth_dev = DEVICE_DT_GET(DT_NODELABEL(eth));
-    if (!device_is_ready(eth_dev)) {
-        LOG_ERR("Ethernet device %s is NOT ready.", eth_dev->name);
-    } else {
-        LOG_DBG("Ethernet device %s is ready.", eth_dev->name);
-    }
+	const struct device *eth_dev = DEVICE_DT_GET(DT_NODELABEL(eth));
+	if (!device_is_ready(eth_dev)) {
+		LOG_ERR("Ethernet device %s is NOT ready.", eth_dev->name);
+	} else {
+		LOG_DBG("Ethernet device %s is ready.", eth_dev->name);
+	}
 #else
-    LOG_ERR("Ethernet device node is not okay in Device Tree.");
-#endif		
+	LOG_ERR("Ethernet device node is not okay in Device Tree.");
+#endif
 }
 
 static void eth_tsn_nic_isr(const struct device *dev)
@@ -149,8 +149,8 @@ static void tx_desc_set(struct dma_tsn_nic_desc *desc, uintptr_t addr, uint32_t 
 	desc->dst_addr_hi = 0;
 
 	desc->src_addr_lo = sys_cpu_to_le32(PCI_DMA_L(addr));
-	desc->src_addr_hi = sys_cpu_to_le32(PCI_DMA_H(addr));	
-	desc->bytes = sys_cpu_to_le32(len);	
+	desc->src_addr_hi = sys_cpu_to_le32(PCI_DMA_H(addr));
+	desc->bytes = sys_cpu_to_le32(len);
 }
 
 static void rx_desc_set(struct dma_tsn_nic_desc *desc, uintptr_t addr, uint32_t len)
@@ -164,8 +164,8 @@ static void rx_desc_set(struct dma_tsn_nic_desc *desc, uintptr_t addr, uint32_t 
 	control |= DESC_COMPLETED;
 	desc->control = sys_cpu_to_le32(control);
 
-    desc->src_addr_lo = 0;
-    desc->src_addr_hi = 0;	
+	desc->src_addr_lo = 0;
+	desc->src_addr_hi = 0;
 
 	desc->dst_addr_lo = sys_cpu_to_le32(PCI_DMA_L(addr));
 	desc->dst_addr_hi = sys_cpu_to_le32(PCI_DMA_H(addr));
@@ -378,7 +378,7 @@ static int eth_tsn_nic_send(const struct device *dev, struct net_pkt *pkt)
 
 	LOG_DBG("eth_tsn_nic_send");
 
-	tsn_print_top_registers(dev);		
+	tsn_print_top_registers(dev);
 
 	eth_tsn_check_status();
 
@@ -390,22 +390,21 @@ static int eth_tsn_nic_send(const struct device *dev, struct net_pkt *pkt)
 
 	ret = net_pkt_read(pkt, data->tx_buffer.data, len);
 	if (ret != 0) {
-		LOG_ERR("eth_tsn_nic_send data length: %lu (net_pkt_read: %d)\n", len, ret);	
+		LOG_ERR("eth_tsn_nic_send data length: %lu (net_pkt_read: %d)\n", len, ret);
 		goto error;
 	}
 
 	if (len < ETH_ZLEN) {
 		len = ETH_ZLEN;
-	}	
-
+	}
 
 	data->tx_buffer.metadata.frame_length = len;
 
-	LOG_DBG("eth_tsn_nic_send data length: %d\n", data->tx_buffer.metadata.frame_length);		
+	LOG_DBG("eth_tsn_nic_send data length: %d\n", data->tx_buffer.metadata.frame_length);
 
 	ret = clock_gettime(CLOCK_MONOTONIC, &ts); /* TODO: Replace with HW clock */
 	if (ret != 0) {
-		LOG_ERR("eth_tsn_nic_send clock_gettime error: %d\n", ret);	
+		LOG_ERR("eth_tsn_nic_send clock_gettime error: %d\n", ret);
 		goto error;
 	}
 
@@ -421,7 +420,7 @@ static int eth_tsn_nic_send(const struct device *dev, struct net_pkt *pkt)
 #endif /* CONFIG_NET_PKT_TIMESTMP */
 
 	tx_desc_set(&data->tx_desc, (uintptr_t)&data->tx_buffer, len + TX_METADATA_SIZE);
- 	
+
 	w = sys_cpu_to_le32(PCI_DMA_L((uintptr_t)&data->tx_desc));
 	sys_write32(w, data->bar[DMA_CONFIG_BAR_IDX] + DESC_REG_LO);
 	w = sys_cpu_to_le32(PCI_DMA_H((uintptr_t)&data->tx_desc));
@@ -431,16 +430,17 @@ static int eth_tsn_nic_send(const struct device *dev, struct net_pkt *pkt)
 	sys_write32(DMA_ENGINE_START, (uintptr_t)&data->regs[DMA_H2C]->control);
 
 	LOG_INF("control: %08x", data->regs[DMA_H2C]->control);
-	LOG_INF("status: %08x", data->regs[DMA_H2C]->status);	
-	LOG_INF("status_rc: %08x", data->regs[DMA_H2C]->status_rc);		
+	LOG_INF("status: %08x", data->regs[DMA_H2C]->status);
+	LOG_INF("status_rc: %08x", data->regs[DMA_H2C]->status_rc);
 
 	LOG_DESC(&data->tx_desc);
 
-	dump_dma_h2c_all_regs(data->regs[DMA_H2C]);	
+	dump_dma_h2c_all_regs(data->regs[DMA_H2C]);
 
-	uint32_t completed = sys_read32((uintptr_t)data->regs[DMA_H2C] + 0x48);  // offset = completed_desc_count
+	uint32_t completed =
+		sys_read32((uintptr_t)data->regs[DMA_H2C] + 0x48); // offset = completed_desc_count
 	LOG_DBG("Completed Desc Count: %d\n", completed);
-	
+
 	uint32_t nCompleted = 0;
 	for (int i = 0; i < 100000; ++i) {
 		uint32_t completed = sys_read32((uintptr_t)data->regs[DMA_H2C] + 0x48);
@@ -602,7 +602,7 @@ static int eth_tsn_nic_init(const struct device *dev)
 	sys_write32(0x800f0000, data->bar[0] + 0x0610);
 	sys_write32(0x10, data->bar[0] + 0x0620);
 
-	tsn_print_top_registers(dev);	
+	tsn_print_top_registers(dev);
 
 	pthread_spin_init(&data->tx_lock, PTHREAD_PROCESS_PRIVATE);
 	pthread_spin_init(&data->rx_lock, PTHREAD_PROCESS_PRIVATE);
@@ -623,9 +623,8 @@ static int eth_tsn_nic_init(const struct device *dev)
 	printk("C2H engine control: 0x%08x\n",
 	       sys_read32((mem_addr_t)&data->regs[DMA_C2H]->control));
 
-    printk("MAC addr: %02X-%02X-%02X-%02X-%02X-%02X\n",
-			data->mac_addr[0],data->mac_addr[1],data->mac_addr[2],
-			data->mac_addr[3],data->mac_addr[4],data->mac_addr[5]); 
+	printk("MAC addr: %02X-%02X-%02X-%02X-%02X-%02X\n", data->mac_addr[0], data->mac_addr[1],
+	       data->mac_addr[2], data->mac_addr[3], data->mac_addr[4], data->mac_addr[5]);
 	return 0;
 }
 

--- a/drivers/ethernet/eth_tsn_nic.c
+++ b/drivers/ethernet/eth_tsn_nic.c
@@ -8,7 +8,7 @@
 #define DT_DRV_COMPAT tsnlab_tsn_nic_eth
 
 #include <zephyr/logging/log.h>
-LOG_MODULE_REGISTER(eth_tsn_nic, LOG_LEVEL_ERR);
+LOG_MODULE_REGISTER(eth_tsn_nic, LOG_LEVEL_DBG);
 
 #include <zephyr/arch/common/sys_bitops.h>
 #include <zephyr/arch/cpu.h>
@@ -29,6 +29,107 @@ LOG_MODULE_REGISTER(eth_tsn_nic, LOG_LEVEL_ERR);
 #include "eth.h"
 #include "eth_tsn_nic_priv.h"
 
+#define RX_DESC_NODE DT_NODELABEL(tsn_dma0)
+#define RES_NODE     DT_NODELABEL(tsn_res_region)
+
+#define RX_DESC_ADDR DT_REG_ADDR(RX_DESC_NODE)
+#define RES_ADDR     DT_REG_ADDR(RES_NODE)
+
+//////////////////////////////////////
+#define TSN_REG_VERSION         0x0000
+#define TSN_REG_CONFIG          0x0004
+#define TSN_REG_CONTROL         0x0008
+#define TSN_REG_SCRATCH         0x0010
+#define TSN_REG_QBV_SLOT_STATUS 0x0028
+#define TSN_REG_PULSE_AT_HI     0x002C
+#define TSN_REG_PULSE_AT_LO     0x0030
+#define TSN_REG_CYCLE_1S        0x0034
+
+#define TSN_REG_TEMAC_STATUS	0x0500
+//////////////////////////////////////
+
+static inline uint32_t fpga_reg_read(const struct device *dev, uint32_t offset)
+{
+	struct eth_tsn_nic_data *data = dev->data;
+
+    return sys_read32((mem_addr_t)(data->bar[0] + offset));
+}
+
+void tsn_print_top_registers(const struct device *dev)
+{
+    LOG_DBG(">>> TSN TOP Register Group <<<");
+    LOG_DBG("TSN_VERSION          (0x%04x): 0x%08x", TSN_REG_VERSION,
+           fpga_reg_read(dev, TSN_REG_VERSION));
+    LOG_DBG("TSN_CONFIG           (0x%04x): 0x%08x", TSN_REG_CONFIG,
+           fpga_reg_read(dev, TSN_REG_CONFIG));		
+    LOG_DBG("TSN_CONTROL          (0x%04x): 0x%08x", TSN_REG_CONTROL,
+           fpga_reg_read(dev, TSN_REG_CONTROL));		
+    LOG_DBG("SCRATCH              (0x%04x): 0x%08x", TSN_REG_SCRATCH,
+           fpga_reg_read(dev, TSN_REG_SCRATCH));		
+    LOG_DBG("QBV_SLOT_STATUS      (0x%04x): 0x%08x", TSN_REG_QBV_SLOT_STATUS,
+           fpga_reg_read(dev, TSN_REG_QBV_SLOT_STATUS));		
+    LOG_DBG("PULSE_AT_HI [63:32]  (0x%04x): 0x%08x", TSN_REG_PULSE_AT_HI,
+           fpga_reg_read(dev, TSN_REG_PULSE_AT_HI));		
+    LOG_DBG("PULSE_AT_LO [31:0]   (0x%04x): 0x%08x", TSN_REG_PULSE_AT_LO,
+           fpga_reg_read(dev, TSN_REG_PULSE_AT_LO));		
+    LOG_DBG("CYCLE_1S             (0x%04x): 0x%08x", TSN_REG_CYCLE_1S,
+           fpga_reg_read(dev, TSN_REG_CYCLE_1S));		
+    LOG_DBG("TEMAC_STATUS         (0x%04x): 0x%08x", TSN_REG_TEMAC_STATUS,
+           fpga_reg_read(dev, TSN_REG_TEMAC_STATUS));				   
+}
+
+void dump_dma_h2c_all_regs(struct dma_tsn_nic_engine_regs *regs)
+{
+    LOG_DBG("=== DMA Engine Registers ===");
+
+    LOG_DBG("identifier              : 0x%08x", regs->identifier);
+    LOG_DBG("control                 : 0x%08x", regs->control);
+    LOG_DBG("control_w1s             : 0x%08x", regs->control_w1s);
+    LOG_DBG("control_w1c             : 0x%08x", regs->control_w1c);
+
+    LOG_DBG("status                  : 0x%08x", regs->status);
+    LOG_DBG("status_rc               : 0x%08x", regs->status_rc);
+    LOG_DBG("completed_desc_count    : 0x%08x", regs->completed_desc_count);
+    LOG_DBG("alignments              : 0x%08x", regs->alignments);
+
+    LOG_DBG("poll_mode_wb_lo         : 0x%08x", regs->poll_mode_wb_lo);
+    LOG_DBG("poll_mode_wb_hi         : 0x%08x", regs->poll_mode_wb_hi);
+
+    LOG_DBG("interrupt_enable_mask   : 0x%08x", regs->interrupt_enable_mask);
+    LOG_DBG("int_en_mask_w1s         : 0x%08x", regs->interrupt_enable_mask_w1s);
+    LOG_DBG("int_en_mask_w1c         : 0x%08x", regs->interrupt_enable_mask_w1c);
+
+    LOG_DBG("perf_ctrl               : 0x%08x", regs->perf_ctrl);
+    LOG_DBG("perf_cyc_lo             : 0x%08x", regs->perf_cyc_lo);
+    LOG_DBG("perf_cyc_hi             : 0x%08x", regs->perf_cyc_hi);
+    LOG_DBG("perf_dat_lo             : 0x%08x", regs->perf_dat_lo);
+    LOG_DBG("perf_dat_hi             : 0x%08x", regs->perf_dat_hi);
+    LOG_DBG("perf_pnd_lo             : 0x%08x", regs->perf_pnd_lo);
+    LOG_DBG("perf_pnd_hi             : 0x%08x", regs->perf_pnd_hi);
+
+    LOG_DBG("===========================");
+}
+
+static void eth_tsn_check_status()
+{
+#if DT_NODE_HAS_STATUS(DT_NODELABEL(pcie1), okay)
+   	LOG_DBG("PCIe controller is okay.");
+#else
+	LOG_ERR("PCIe controller is NOT okay.");
+#endif
+
+#if DT_NODE_HAS_STATUS(DT_NODELABEL(eth), okay)
+    const struct device *eth_dev = DEVICE_DT_GET(DT_NODELABEL(eth));
+    if (!device_is_ready(eth_dev)) {
+        LOG_ERR("Ethernet device %s is NOT ready.", eth_dev->name);
+    } else {
+        LOG_DBG("Ethernet device %s is ready.", eth_dev->name);
+    }
+#else
+    LOG_ERR("Ethernet device node is not okay in Device Tree.");
+#endif		
+}
+
 static void eth_tsn_nic_isr(const struct device *dev)
 {
 	/* TODO: Implement interrupts */
@@ -37,17 +138,19 @@ static void eth_tsn_nic_isr(const struct device *dev)
 
 static void tx_desc_set(struct dma_tsn_nic_desc *desc, uintptr_t addr, uint32_t len)
 {
-	uint32_t control;
+	uint32_t control = DESC_MAGIC;
 
-	desc->control = sys_cpu_to_le32(DESC_MAGIC);
-	control = sys_le32_to_cpu(desc->control & ~(LS_BYTE_MASK));
+	control &= ~(LS_BYTE_MASK);
 	control |= DESC_STOPPED;
 	control |= DESC_EOP;
 	control |= DESC_COMPLETED;
-	desc->control = sys_cpu_to_le32(control);
+	desc->control |= sys_cpu_to_le32(control);
 
 	desc->src_addr_lo = sys_cpu_to_le32(PCI_DMA_L(addr));
 	desc->src_addr_hi = sys_cpu_to_le32(PCI_DMA_H(addr));
+
+    desc->dst_addr_lo = 0;
+    desc->dst_addr_hi = 0;		
 	desc->bytes = sys_cpu_to_le32(len);
 }
 
@@ -61,6 +164,9 @@ static void rx_desc_set(struct dma_tsn_nic_desc *desc, uintptr_t addr, uint32_t 
 	control |= DESC_EOP;
 	control |= DESC_COMPLETED;
 	desc->control = sys_cpu_to_le32(control);
+
+    desc->src_addr_lo = 0;
+    desc->src_addr_hi = 0;	
 
 	desc->dst_addr_lo = sys_cpu_to_le32(PCI_DMA_L(addr));
 	desc->dst_addr_hi = sys_cpu_to_le32(PCI_DMA_H(addr));
@@ -92,19 +198,19 @@ static void eth_tsn_nic_rx(struct k_work *item)
 	pkt = net_pkt_rx_alloc_with_buffer(data->iface, pkt_len, AF_UNSPEC, 0, K_NO_WAIT);
 	if (pkt == NULL) {
 		/* TODO: stats */
-		printk("alloc failed\n");
+		LOG_ERR("alloc failed\n");
 		goto done;
 	}
 
 	ret = net_pkt_write(pkt, data->rx_buffer.data, pkt_len);
 	if (ret != 0) {
-		printk("write failed\n");
+		LOG_ERR("write failed\n");
 		goto done;
 	}
 
 	ret = net_recv_data(data->iface, pkt);
 	if (ret != 0) {
-		printk("recv failed\n");
+		LOG_ERR("recv failed\n");
 		goto done;
 	}
 
@@ -271,23 +377,36 @@ static int eth_tsn_nic_send(const struct device *dev, struct net_pkt *pkt)
 	k_work_submit(&data->rx_work); /* TODO: use polling for now */
 #endif
 
+	LOG_DBG("eth_tsn_nic_send");
+
+	tsn_print_top_registers(dev);		
+
+	eth_tsn_check_status();
+
 	pthread_spin_lock(&data->tx_lock);
 
 	len = net_pkt_get_len(pkt);
 
 	memset(data->tx_buffer.data, 0, sizeof(data->tx_buffer.data));
+
 	ret = net_pkt_read(pkt, data->tx_buffer.data, len);
 	if (ret != 0) {
+		LOG_ERR("eth_tsn_nic_send data length: %lu (net_pkt_read: %d)\n", len, ret);	
 		goto error;
 	}
 
 	if (len < ETH_ZLEN) {
 		len = ETH_ZLEN;
 	}	
+
+
 	data->tx_buffer.metadata.frame_length = len;
+
+	LOG_DBG("eth_tsn_nic_send data length: %d\n", data->tx_buffer.metadata.frame_length);		
 
 	ret = clock_gettime(CLOCK_MONOTONIC, &ts); /* TODO: Replace with HW clock */
 	if (ret != 0) {
+		LOG_ERR("eth_tsn_nic_send clock_gettime error: %d\n", ret);	
 		goto error;
 	}
 
@@ -303,15 +422,36 @@ static int eth_tsn_nic_send(const struct device *dev, struct net_pkt *pkt)
 #endif /* CONFIG_NET_PKT_TIMESTMP */
 
 	tx_desc_set(&data->tx_desc, (uintptr_t)&data->tx_buffer, len + TX_METADATA_SIZE);
-
-	/* These are just pseudo codes for now */
+ 	
 	w = sys_cpu_to_le32(PCI_DMA_L((uintptr_t)&data->tx_desc));
 	sys_write32(w, data->bar[DMA_CONFIG_BAR_IDX] + DESC_REG_LO);
 	w = sys_cpu_to_le32(PCI_DMA_H((uintptr_t)&data->tx_desc));
 	sys_write32(w, data->bar[DMA_CONFIG_BAR_IDX] + DESC_REG_HI);
 	sys_write32(0, data->bar[DMA_CONFIG_BAR_IDX] + DESC_REG_HI);
 	sys_write32(0, data->bar[DMA_CONFIG_BAR_IDX] + DESC_REG_HI + 4);
-	sys_write32(DMA_ENGINE_START, data->regs[DMA_H2C]->control);
+	sys_write32(DMA_ENGINE_START, (uintptr_t)&data->regs[DMA_H2C]->control);
+
+	LOG_INF("control: %08x", data->regs[DMA_H2C]->control);
+	LOG_INF("status: %08x", data->regs[DMA_H2C]->status);	
+	LOG_INF("status_rc: %08x", data->regs[DMA_H2C]->status_rc);		
+
+	LOG_DESC(&data->tx_desc);
+
+	dump_dma_h2c_all_regs(data->regs[DMA_H2C]);	
+
+	uint32_t completed = sys_read32((uintptr_t)data->regs[DMA_H2C] + 0x48);  // offset = completed_desc_count
+	LOG_DBG("Completed Desc Count: %d\n", completed);
+	
+	uint32_t nCompleted = 0;
+	for (int i = 0; i < 100000; ++i) {
+		uint32_t completed = sys_read32((uintptr_t)data->regs[DMA_H2C] + 0x48);
+		if (completed > 0) {
+			LOG_DBG("DMA completed!\n");
+			nCompleted++;
+			break;
+		}
+		k_busy_wait(10); // 10 µs delay
+	}
 
 	/* TODO: This should be done in tsn_nic_isr() */
 	pthread_spin_unlock(&data->tx_lock);
@@ -379,11 +519,15 @@ static int engine_init_regs(struct dma_tsn_nic_engine_regs *regs)
 		 DMA_CTRL_IE_IDLE_STOPPED | DMA_CTRL_IE_READ_ERROR | DMA_CTRL_IE_DESC_ERROR |
 		 DMA_CTRL_IE_DESC_STOPPED | DMA_CTRL_IE_DESC_COMPLETED);
 
+	flags = 0xf83e1e;
+
 	sys_write32(flags, (mem_addr_t)&regs->interrupt_enable_mask);
 
 	flags = (DMA_CTRL_RUN_STOP | DMA_CTRL_IE_READ_ERROR | DMA_CTRL_IE_DESC_ERROR |
 		 DMA_CTRL_IE_DESC_ALIGN_MISMATCH | DMA_CTRL_IE_MAGIC_STOPPED |
 		 DMA_CTRL_POLL_MODE_WB);
+
+	flags = 0xf83e1e;	 
 
 	sys_write32(flags, (mem_addr_t)&regs->control);
 
@@ -420,7 +564,10 @@ static int eth_tsn_nic_init(const struct device *dev)
 	struct dma_tsn_nic_engine_regs *regs;
 	int engine_id, channel_id;
 
+	LOG_DBG("device name: %s", dev->name);
+
 	if (map_bar(dev, 0, 0x1000) != 0) {
+		LOG_ERR("Failed to map BAR 0\n");
 		return -EINVAL;
 	}
 
@@ -460,6 +607,8 @@ static int eth_tsn_nic_init(const struct device *dev)
 	sys_write32(0x800f0000, data->bar[0] + 0x0610);
 	sys_write32(0x10, data->bar[0] + 0x0620);
 
+	tsn_print_top_registers(dev);	
+
 	pthread_spin_init(&data->tx_lock, PTHREAD_PROCESS_PRIVATE);
 	pthread_spin_init(&data->rx_lock, PTHREAD_PROCESS_PRIVATE);
 
@@ -479,6 +628,9 @@ static int eth_tsn_nic_init(const struct device *dev)
 	printk("C2H engine control: 0x%08x\n",
 	       sys_read32((mem_addr_t)&data->regs[DMA_C2H]->control));
 
+    printk("MAC addr: %02X-%02X-%02X-%02X-%02X-%02X\n",
+			data->mac_addr[0],data->mac_addr[1],data->mac_addr[2],
+			data->mac_addr[3],data->mac_addr[4],data->mac_addr[5]); 
 	return 0;
 }
 

--- a/drivers/ethernet/eth_tsn_nic.c
+++ b/drivers/ethernet/eth_tsn_nic.c
@@ -438,7 +438,7 @@ static int eth_tsn_nic_send(const struct device *dev, struct net_pkt *pkt)
 
 	/* offset = completed_desc_count */
 	uint32_t completed =
-		sys_read32((uintptr_t)data->regs[DMA_H2C] + 0x48); 
+		sys_read32((uintptr_t)data->regs[DMA_H2C] + 0x48);
 
 	LOG_DBG("Completed Desc Count: %d\n", completed);
 

--- a/drivers/ethernet/eth_tsn_nic.c
+++ b/drivers/ethernet/eth_tsn_nic.c
@@ -118,6 +118,7 @@ static void eth_tsn_check_status(void)
 
 #if DT_NODE_HAS_STATUS(DT_NODELABEL(eth), okay)
 	const struct device *eth_dev = DEVICE_DT_GET(DT_NODELABEL(eth));
+
 	if (!device_is_ready(eth_dev)) {
 		LOG_ERR("Ethernet device %s is NOT ready.", eth_dev->name);
 	} else {
@@ -435,8 +436,10 @@ static int eth_tsn_nic_send(const struct device *dev, struct net_pkt *pkt)
 
 	dump_dma_h2c_all_regs(data->regs[DMA_H2C]);
 
+	/* offset = completed_desc_count */
 	uint32_t completed =
-		sys_read32((uintptr_t)data->regs[DMA_H2C] + 0x48); /* offset = completed_desc_count */
+		sys_read32((uintptr_t)data->regs[DMA_H2C] + 0x48); 
+
 	LOG_DBG("Completed Desc Count: %d\n", completed);
 
 	uint32_t nCompleted = 0;

--- a/drivers/ethernet/eth_tsn_nic_priv.h
+++ b/drivers/ethernet/eth_tsn_nic_priv.h
@@ -65,19 +65,21 @@
 #define DMA_ENGINE_START 16268831
 #define DMA_ENGINE_STOP  16268830
 
-// DMA_ENGINE_START (0x00F83E1F) 16268831
-// 0xF8001F = 1111 1000 0000 0000 0001 1111 (binary)
-//            |     |               |     +--> bit [0:0] Run (start the SGDMA engine)
-//            |     |               +--> bits [4:0]  = 1Fh (all 1s, i.e., enable all ie_* error interrupts)
-//            |     +--> bits [23:19] = 0x1F (enable all ie_desc_error interrupts)
-//            +--> bits [31:24] = 0xF8 (only top 4 bits used, which are reserved)
+/*
+DMA_ENGINE_START (0x00F83E1F) 16268831
+0xF8001F = 1111 1000 0000 0000 0001 1111 (binary)
+           |     |               |     +--> bit [0:0] Run (start the SGDMA engine)
+           |     |               +--> bits [4:0]  = 1Fh (all 1s, i.e., enable all ie_* error interrupts)
+           |     +--> bits [23:19] = 0x1F (enable all ie_desc_error interrupts)
+           +--> bits [31:24] = 0xF8 (only top 4 bits used, which are reserved)
 
-// DMA_ENGINE_STOP  (0x00F83E1E) //16268830
-// 0xF8001E = 1111 1000 0000 0000 0001 1110 (binary)
-//            |     |               |     +--> bit [0:0] Stop transfer (if the engine is busy, it completes the current descriptor)
-//            |     |               +--> bits [4:0]  = 1Eh (all 1s, i.e., enable all ie_* error interrupts)
-//            |     +--> bits [23:19] = 0x1F (enable all ie_desc_error interrupts)
-//            +--> bits [31:24] = 0xF8 (only top 4 bits used, which are reserved)
+DMA_ENGINE_STOP  (0x00F83E1E) //16268830
+0xF8001E = 1111 1000 0000 0000 0001 1110 (binary)
+           |     |               |     +--> bit [0:0] Stop transfer (if the engine is busy, it completes the current descriptor)
+           |     |               +--> bits [4:0]  = 1Eh (all 1s, i.e., enable all ie_* error interrupts)
+           |     +--> bits [23:19] = 0x1F (enable all ie_desc_error interrupts)
+           +--> bits [31:24] = 0xF8 (only top 4 bits used, which are reserved)
+*/
 
 #define ETH_ALEN 6
 

--- a/drivers/ethernet/eth_tsn_nic_priv.h
+++ b/drivers/ethernet/eth_tsn_nic_priv.h
@@ -166,18 +166,19 @@ struct dma_tsn_nic_result {
 	uint32_t _reserved1[6]; /* padding */
 };
 
-#define LOG_DESC(desc_ptr) do { \
-const struct dma_tsn_nic_desc *desc = (desc_ptr); \
-LOG_DBG("DMA DESC @ %p:", desc); \
-LOG_DBG("  control     : 0x%08x", desc->control); \
-LOG_DBG("  bytes       : 0x%08x", desc->bytes); \
-LOG_DBG("  src_addr_lo : 0x%08x", desc->src_addr_lo); \
-LOG_DBG("  src_addr_hi : 0x%08x", desc->src_addr_hi); \
-LOG_DBG("  dst_addr_lo : 0x%08x", desc->dst_addr_lo); \
-LOG_DBG("  dst_addr_hi : 0x%08x", desc->dst_addr_hi); \
-LOG_DBG("  next_lo     : 0x%08x", desc->next_lo); \
-LOG_DBG("  next_hi     : 0x%08x", desc->next_hi); \
-} while (0)
+#define LOG_DESC(desc_ptr)	\
+	do {	\
+		const struct dma_tsn_nic_desc *desc = (desc_ptr);	\
+		LOG_DBG("DMA DESC @ %p:", desc);	\
+		LOG_DBG("  control     : 0x%08x", desc->control);	\
+		LOG_DBG("  bytes       : 0x%08x", desc->bytes);	\
+		LOG_DBG("  src_addr_lo : 0x%08x", desc->src_addr_lo);	\
+		LOG_DBG("  src_addr_hi : 0x%08x", desc->src_addr_hi);	\
+		LOG_DBG("  dst_addr_lo : 0x%08x", desc->dst_addr_lo);	\
+		LOG_DBG("  dst_addr_hi : 0x%08x", desc->dst_addr_hi);	\
+		LOG_DBG("  next_lo     : 0x%08x", desc->next_lo);	\
+		LOG_DBG("  next_hi     : 0x%08x", desc->next_hi);	\
+	} while (0)
 
 /**
  * TSN-related items

--- a/drivers/ethernet/eth_tsn_nic_priv.h
+++ b/drivers/ethernet/eth_tsn_nic_priv.h
@@ -65,21 +65,22 @@
 #define DMA_ENGINE_START 16268831
 #define DMA_ENGINE_STOP  16268830
 
-/*
-/* DMA_ENGINE_START (0x00F83E1F) 16268831
-/* 0xF8001F = 1111 1000 0000 0000 0001 1111 (binary)
-/* 		   	  |     |               |     +--> bit [0:0] Run (start the SGDMA engine)
-/*            |     |               +--> bits [4:0]  = 1Fh (all 1s, i.e., enable all ie_* error interrupts)
-/*            |     +--> bits [23:19] = 0x1F (enable all ie_desc_error interrupts)
-/*            +--> bits [31:24] = 0xF8 (only top 4 bits used, which are reserved)
-/*
-/* DMA_ENGINE_STOP  (0x00F83E1E) //16268830
-/* 0xF8001E = 1111 1000 0000 0000 0001 1110 (binary)
-/*            |     |               |     +--> bit [0:0] Stop transfer (if the engine is busy, it completes the current descriptor)
-/*            |     |               +--> bits [4:0]  = 1Eh (all 1s, i.e., enable all ie_* error interrupts)
-/*            |     +--> bits [23:19] = 0x1F (enable all ie_desc_error interrupts)
-/*            +--> bits [31:24] = 0xF8 (only top 4 bits used, which are reserved)
-*/
+/****************************************************************************************************************/
+/* DMA_ENGINE_START (0x00F83E1F) 16268831																		*/
+/* 0xF8001F = 1111 1000 0000 0000 0001 1111 (binary)															*/
+/* 		   	  |     |               |     +--> bit [0:0] Run (start the SGDMA engine)							*/
+/*            |     |               +--> bits [4:0]  = 1Fh (all 1s, i.e., enable all ie_* error interrupts)		*/
+/*            |     +--> bits [23:19] = 0x1F (enable all ie_desc_error interrupts)								*/
+/*            +--> bits [31:24] = 0xF8 (only top 4 bits used, which are reserved)								*/
+/*																												*/
+/* DMA_ENGINE_STOP  (0x00F83E1E) //16268830																		*/
+/* 0xF8001E = 1111 1000 0000 0000 0001 1110 (binary)															*/
+/*            |     |               |     +--> bit [0:0] Stop transfer 											*/
+/*			  |	    |				|		(if the engine is busy, it completes the current descriptor)		*/
+/*            |     |               +--> bits [4:0]  = 1Eh (all 1s, i.e., enable all ie_* error interrupts)		*/
+/*            |     +--> bits [23:19] = 0x1F (enable all ie_desc_error interrupts)								*/
+/*            +--> bits [31:24] = 0xF8 (only top 4 bits used, which are reserved)								*/
+/****************************************************************************************************************/
 
 #define ETH_ALEN 6
 

--- a/drivers/ethernet/eth_tsn_nic_priv.h
+++ b/drivers/ethernet/eth_tsn_nic_priv.h
@@ -65,32 +65,6 @@
 #define DMA_ENGINE_START 16268831
 #define DMA_ENGINE_STOP  16268830
 
-/*
- * DMA_ENGINE_START (0x00F83E1F) 16268831
- * 0xF8001F = 1111 1000 0000 0000 0001 1111 (binary)
- *            |     |               |     +--> bit [0:0] Run
- *            |     |               |     (start the SGDMA engine)
- *            |     |               +--> bits [4:0]  = 1Fh
- *            |     |  (all 1s, i.e., enable all ie_* error interrupts)
- *            |     +--> bits [23:19] = 0x1F
- *            |       (enable all ie_desc_error interrupts)
- *            +--> bits [31:24] = 0xF8
- * 			(only top 4 bits used, which are reserved)
- *
- * DMA_ENGINE_STOP  (0x00F83E1E) //16268830
- * 0xF8001E = 1111 1000 0000 0000 0001 1110 (binary)
- *            |     |               |     +--> bit [0:0]
- * 			  |     |               |    Stop transfer
- *            |     |	  		    |(if the engine is busy,
- * 			  |     |               |it completes the current descriptor)
- *            |     |               +--> bits [4:0]  = 1Eh
- *            |     |  (all 1s, i.e., enable all ie_* error interrupts)
- *            |     +--> bits [23:19] = 0x1F
- *            |     (enable all ie_desc_error interrupts)
- *            +--> bits [31:24] = 0xF8
- * 			(only top 4 bits used, which are reserved)
-*/
-
 #define ETH_ALEN 6
 
 #define BUFFER_SIZE 1500 /* Ethernet MTU */

--- a/drivers/ethernet/eth_tsn_nic_priv.h
+++ b/drivers/ethernet/eth_tsn_nic_priv.h
@@ -65,22 +65,22 @@
 #define DMA_ENGINE_START 16268831
 #define DMA_ENGINE_STOP  16268830
 
-/****************************************************************************************************************/
-/* DMA_ENGINE_START (0x00F83E1F) 16268831																		*/
-/* 0xF8001F = 1111 1000 0000 0000 0001 1111 (binary)															*/
-/* 		   	  |     |               |     +--> bit [0:0] Run (start the SGDMA engine)							*/
-/*            |     |               +--> bits [4:0]  = 1Fh (all 1s, i.e., enable all ie_* error interrupts)		*/
-/*            |     +--> bits [23:19] = 0x1F (enable all ie_desc_error interrupts)								*/
-/*            +--> bits [31:24] = 0xF8 (only top 4 bits used, which are reserved)								*/
-/*																												*/
-/* DMA_ENGINE_STOP  (0x00F83E1E) //16268830																		*/
-/* 0xF8001E = 1111 1000 0000 0000 0001 1110 (binary)															*/
-/*            |     |               |     +--> bit [0:0] Stop transfer 											*/
-/*			  |	    |				|		(if the engine is busy, it completes the current descriptor)		*/
-/*            |     |               +--> bits [4:0]  = 1Eh (all 1s, i.e., enable all ie_* error interrupts)		*/
-/*            |     +--> bits [23:19] = 0x1F (enable all ie_desc_error interrupts)								*/
-/*            +--> bits [31:24] = 0xF8 (only top 4 bits used, which are reserved)								*/
-/****************************************************************************************************************/
+/*
+/* DMA_ENGINE_START (0x00F83E1F) 16268831
+/* 0xF8001F = 1111 1000 0000 0000 0001 1111 (binary)
+/* 		   	  |     |               |     +--> bit [0:0] Run (start the SGDMA engine)
+/*            |     |               +--> bits [4:0]  = 1Fh (all 1s, i.e., enable all ie_* error interrupts)
+/*            |     +--> bits [23:19] = 0x1F (enable all ie_desc_error interrupts)
+/*            +--> bits [31:24] = 0xF8 (only top 4 bits used, which are reserved)
+/*
+/* DMA_ENGINE_STOP  (0x00F83E1E) //16268830
+/* 0xF8001E = 1111 1000 0000 0000 0001 1110 (binary)
+/*            |     |               |     +--> bit [0:0] Stop transfer
+/*			  |	    |				|		(if the engine is busy, it completes the current descriptor)
+/*            |     |               +--> bits [4:0]  = 1Eh (all 1s, i.e., enable all ie_* error interrupts)
+/*            |     +--> bits [23:19] = 0x1F (enable all ie_desc_error interrupts)
+/*            +--> bits [31:24] = 0xF8 (only top 4 bits used, which are reserved)
+*/
 
 #define ETH_ALEN 6
 

--- a/drivers/ethernet/eth_tsn_nic_priv.h
+++ b/drivers/ethernet/eth_tsn_nic_priv.h
@@ -66,20 +66,20 @@
 #define DMA_ENGINE_STOP  16268830
 
 /*
-/* DMA_ENGINE_START (0x00F83E1F) 16268831
-/* 0xF8001F = 1111 1000 0000 0000 0001 1111 (binary)
-/* 		   	  |     |               |     +--> bit [0:0] Run (start the SGDMA engine)
-/*            |     |               +--> bits [4:0]  = 1Fh (all 1s, i.e., enable all ie_* error interrupts)
-/*            |     +--> bits [23:19] = 0x1F (enable all ie_desc_error interrupts)
-/*            +--> bits [31:24] = 0xF8 (only top 4 bits used, which are reserved)
-/*
-/* DMA_ENGINE_STOP  (0x00F83E1E) //16268830
-/* 0xF8001E = 1111 1000 0000 0000 0001 1110 (binary)
-/*            |     |               |     +--> bit [0:0] Stop transfer
-/*			  |	    |				|		(if the engine is busy, it completes the current descriptor)
-/*            |     |               +--> bits [4:0]  = 1Eh (all 1s, i.e., enable all ie_* error interrupts)
-/*            |     +--> bits [23:19] = 0x1F (enable all ie_desc_error interrupts)
-/*            +--> bits [31:24] = 0xF8 (only top 4 bits used, which are reserved)
+* DMA_ENGINE_START (0x00F83E1F) 16268831
+* 0xF8001F = 1111 1000 0000 0000 0001 1111 (binary)
+*            |     |               |     +--> bit [0:0] Run (start the SGDMA engine)
+*            |     |               +--> bits [4:0]  = 1Fh (all 1s, i.e., enable all ie_* error interrupts)
+*            |     +--> bits [23:19] = 0x1F (enable all ie_desc_error interrupts)
+*            +--> bits [31:24] = 0xF8 (only top 4 bits used, which are reserved)
+*
+* DMA_ENGINE_STOP  (0x00F83E1E) //16268830
+* 0xF8001E = 1111 1000 0000 0000 0001 1110 (binary)
+*            |     |               |     +--> bit [0:0] Stop transfer
+*            |     |	  		   |		(if the engine is busy, it completes the current descriptor)
+*            |     |               +--> bits [4:0]  = 1Eh (all 1s, i.e., enable all ie_* error interrupts)
+*            |     +--> bits [23:19] = 0x1F (enable all ie_desc_error interrupts)
+*            +--> bits [31:24] = 0xF8 (only top 4 bits used, which are reserved)
 */
 
 #define ETH_ALEN 6

--- a/drivers/ethernet/eth_tsn_nic_priv.h
+++ b/drivers/ethernet/eth_tsn_nic_priv.h
@@ -66,19 +66,19 @@
 #define DMA_ENGINE_STOP  16268830
 
 /*
-DMA_ENGINE_START (0x00F83E1F) 16268831
-0xF8001F = 1111 1000 0000 0000 0001 1111 (binary)
-           |     |               |     +--> bit [0:0] Run (start the SGDMA engine)
-           |     |               +--> bits [4:0]  = 1Fh (all 1s, i.e., enable all ie_* error interrupts)
-           |     +--> bits [23:19] = 0x1F (enable all ie_desc_error interrupts)
-           +--> bits [31:24] = 0xF8 (only top 4 bits used, which are reserved)
-
-DMA_ENGINE_STOP  (0x00F83E1E) //16268830
-0xF8001E = 1111 1000 0000 0000 0001 1110 (binary)
-           |     |               |     +--> bit [0:0] Stop transfer (if the engine is busy, it completes the current descriptor)
-           |     |               +--> bits [4:0]  = 1Eh (all 1s, i.e., enable all ie_* error interrupts)
-           |     +--> bits [23:19] = 0x1F (enable all ie_desc_error interrupts)
-           +--> bits [31:24] = 0xF8 (only top 4 bits used, which are reserved)
+/* DMA_ENGINE_START (0x00F83E1F) 16268831
+/* 0xF8001F = 1111 1000 0000 0000 0001 1111 (binary)
+/* 		   	  |     |               |     +--> bit [0:0] Run (start the SGDMA engine)
+/*            |     |               +--> bits [4:0]  = 1Fh (all 1s, i.e., enable all ie_* error interrupts)
+/*            |     +--> bits [23:19] = 0x1F (enable all ie_desc_error interrupts)
+/*            +--> bits [31:24] = 0xF8 (only top 4 bits used, which are reserved)
+/*
+/* DMA_ENGINE_STOP  (0x00F83E1E) //16268830
+/* 0xF8001E = 1111 1000 0000 0000 0001 1110 (binary)
+/*            |     |               |     +--> bit [0:0] Stop transfer (if the engine is busy, it completes the current descriptor)
+/*            |     |               +--> bits [4:0]  = 1Eh (all 1s, i.e., enable all ie_* error interrupts)
+/*            |     +--> bits [23:19] = 0x1F (enable all ie_desc_error interrupts)
+/*            +--> bits [31:24] = 0xF8 (only top 4 bits used, which are reserved)
 */
 
 #define ETH_ALEN 6
@@ -166,16 +166,16 @@ struct dma_tsn_nic_result {
 };
 
 #define LOG_DESC(desc_ptr) do { \
-    const struct dma_tsn_nic_desc *desc = (desc_ptr); \
-    LOG_DBG("DMA DESC @ %p:", desc); \
-    LOG_DBG("  control     : 0x%08x", desc->control); \
-    LOG_DBG("  bytes       : 0x%08x", desc->bytes); \
-    LOG_DBG("  src_addr_lo : 0x%08x", desc->src_addr_lo); \
-    LOG_DBG("  src_addr_hi : 0x%08x", desc->src_addr_hi); \
-    LOG_DBG("  dst_addr_lo : 0x%08x", desc->dst_addr_lo); \
-    LOG_DBG("  dst_addr_hi : 0x%08x", desc->dst_addr_hi); \
-    LOG_DBG("  next_lo     : 0x%08x", desc->next_lo); \
-    LOG_DBG("  next_hi     : 0x%08x", desc->next_hi); \
+const struct dma_tsn_nic_desc *desc = (desc_ptr); \
+LOG_DBG("DMA DESC @ %p:", desc); \
+LOG_DBG("  control     : 0x%08x", desc->control); \
+LOG_DBG("  bytes       : 0x%08x", desc->bytes); \
+LOG_DBG("  src_addr_lo : 0x%08x", desc->src_addr_lo); \
+LOG_DBG("  src_addr_hi : 0x%08x", desc->src_addr_hi); \
+LOG_DBG("  dst_addr_lo : 0x%08x", desc->dst_addr_lo); \
+LOG_DBG("  dst_addr_hi : 0x%08x", desc->dst_addr_hi); \
+LOG_DBG("  next_lo     : 0x%08x", desc->next_lo); \
+LOG_DBG("  next_hi     : 0x%08x", desc->next_hi); \
 } while (0)
 
 /**

--- a/drivers/ethernet/eth_tsn_nic_priv.h
+++ b/drivers/ethernet/eth_tsn_nic_priv.h
@@ -66,20 +66,20 @@
 #define DMA_ENGINE_STOP  16268830
 
 /*
-* DMA_ENGINE_START (0x00F83E1F) 16268831
-* 0xF8001F = 1111 1000 0000 0000 0001 1111 (binary)
-*            |     |               |     +--> bit [0:0] Run (start the SGDMA engine)
-*            |     |               +--> bits [4:0]  = 1Fh (all 1s, i.e., enable all ie_* error interrupts)
-*            |     +--> bits [23:19] = 0x1F (enable all ie_desc_error interrupts)
-*            +--> bits [31:24] = 0xF8 (only top 4 bits used, which are reserved)
-*
-* DMA_ENGINE_STOP  (0x00F83E1E) //16268830
-* 0xF8001E = 1111 1000 0000 0000 0001 1110 (binary)
-*            |     |               |     +--> bit [0:0] Stop transfer
-*            |     |	  		   |		(if the engine is busy, it completes the current descriptor)
-*            |     |               +--> bits [4:0]  = 1Eh (all 1s, i.e., enable all ie_* error interrupts)
-*            |     +--> bits [23:19] = 0x1F (enable all ie_desc_error interrupts)
-*            +--> bits [31:24] = 0xF8 (only top 4 bits used, which are reserved)
+ * DMA_ENGINE_START (0x00F83E1F) 16268831
+ * 0xF8001F = 1111 1000 0000 0000 0001 1111 (binary)
+ *            |     |               |     +--> bit [0:0] Run (start the SGDMA engine)
+ *            |     |               +--> bits [4:0]  = 1Fh (all 1s, i.e., enable all ie_* error interrupts)
+ *            |     +--> bits [23:19] = 0x1F (enable all ie_desc_error interrupts)
+ *            +--> bits [31:24] = 0xF8 (only top 4 bits used, which are reserved)
+ *
+ * DMA_ENGINE_STOP  (0x00F83E1E) //16268830
+ * 0xF8001E = 1111 1000 0000 0000 0001 1110 (binary)
+ *            |     |               |     +--> bit [0:0] Stop transfer
+ *            |     |	  		   |		(if the engine is busy, it completes the current descriptor)
+ *            |     |               +--> bits [4:0]  = 1Eh (all 1s, i.e., enable all ie_* error interrupts)
+ *            |     +--> bits [23:19] = 0x1F (enable all ie_desc_error interrupts)
+ *            +--> bits [31:24] = 0xF8 (only top 4 bits used, which are reserved)
 */
 
 #define ETH_ALEN 6

--- a/drivers/ethernet/eth_tsn_nic_priv.h
+++ b/drivers/ethernet/eth_tsn_nic_priv.h
@@ -68,18 +68,27 @@
 /*
  * DMA_ENGINE_START (0x00F83E1F) 16268831
  * 0xF8001F = 1111 1000 0000 0000 0001 1111 (binary)
- *            |     |               |     +--> bit [0:0] Run (start the SGDMA engine)
- *            |     |               +--> bits [4:0]  = 1Fh (all 1s, i.e., enable all ie_* error interrupts)
- *            |     +--> bits [23:19] = 0x1F (enable all ie_desc_error interrupts)
- *            +--> bits [31:24] = 0xF8 (only top 4 bits used, which are reserved)
+ *            |     |               |     +--> bit [0:0] Run
+ *            |     |               |     (start the SGDMA engine)
+ *            |     |               +--> bits [4:0]  = 1Fh
+ *            |     |  (all 1s, i.e., enable all ie_* error interrupts)
+ *            |     +--> bits [23:19] = 0x1F
+ *            |       (enable all ie_desc_error interrupts)
+ *            +--> bits [31:24] = 0xF8
+ * 			(only top 4 bits used, which are reserved)
  *
  * DMA_ENGINE_STOP  (0x00F83E1E) //16268830
  * 0xF8001E = 1111 1000 0000 0000 0001 1110 (binary)
- *            |     |               |     +--> bit [0:0] Stop transfer
- *            |     |	  		   |		(if the engine is busy, it completes the current descriptor)
- *            |     |               +--> bits [4:0]  = 1Eh (all 1s, i.e., enable all ie_* error interrupts)
- *            |     +--> bits [23:19] = 0x1F (enable all ie_desc_error interrupts)
- *            +--> bits [31:24] = 0xF8 (only top 4 bits used, which are reserved)
+ *            |     |               |     +--> bit [0:0]
+ * 			  |     |               |    Stop transfer
+ *            |     |	  		    |(if the engine is busy,
+ * 			  |     |               |it completes the current descriptor)
+ *            |     |               +--> bits [4:0]  = 1Eh
+ *            |     |  (all 1s, i.e., enable all ie_* error interrupts)
+ *            |     +--> bits [23:19] = 0x1F
+ *            |     (enable all ie_desc_error interrupts)
+ *            +--> bits [31:24] = 0xF8
+ * 			(only top 4 bits used, which are reserved)
 */
 
 #define ETH_ALEN 6

--- a/drivers/pcie/controller/pcie_brcmstb.c
+++ b/drivers/pcie/controller/pcie_brcmstb.c
@@ -720,12 +720,12 @@ static int pcie_brcmstb_setup(const struct device *dev)
 	LOG_DBG("PCIE_MISC_RC_BAR3_CONFIG_LO after write: 0x%x",
 		sys_read32(data->cfg_addr + PCIE_MISC_RC_BAR3_CONFIG_LO));
 
-	/* 1. Reset Sequence */ 
-	/* Assert PERST# */ 
+	/* 1. Reset Sequence */
+	/* Assert PERST# */
 	LOG_INF("Asserting PERST#");
-	/* Assuming pcie->cfg->perst_set is available in your Zephyr environment */ 
-	/* If not, you'll need to use the appropriate board-specific GPIO control */ 
-	/* to assert the reset. */ 
+	/* Assuming pcie->cfg->perst_set is available in your Zephyr environment */
+	/* If not, you'll need to use the appropriate board-specific GPIO control */
+	/* to assert the reset. */
 	/* ret = pcie->cfg->perst_set(pcie, 1); // Assert reset */
 	/* if (ret) { */
 	/*     LOG_ERR("Failed to assert PERST#"); */
@@ -804,7 +804,7 @@ static int pcie_brcmstb_setup(const struct device *dev)
 
 	uint16_t lnksta = sys_read16(data->cfg_addr + BRCM_PCIE_CAP_REGS + PCI_EXP_LNKSTA_OFFSET);
 
-	LOG_DBG("PCI_EXP_LNKSTA value: 0x%x", lnksta);	
+	LOG_DBG("PCI_EXP_LNKSTA value: 0x%x", lnksta);
 	if (lnksta & PCI_EXP_LNKSTA_DLLLA) {
 		LOG_INF("Data Link Layer is active.");
 	} else {

--- a/drivers/pcie/controller/pcie_brcmstb.c
+++ b/drivers/pcie/controller/pcie_brcmstb.c
@@ -5,7 +5,7 @@
  */
 
 #include <zephyr/logging/log.h>
-LOG_MODULE_REGISTER(pcie_brcmstb, LOG_LEVEL_ERR);
+LOG_MODULE_REGISTER(pcie_brcmstb, LOG_LEVEL_INF);
 
 #include <zephyr/kernel.h>
 #include <zephyr/device.h>
@@ -153,7 +153,7 @@ LOG_MODULE_REGISTER(pcie_brcmstb, LOG_LEVEL_ERR);
 
 #define SET_ADDR_OFFSET 0x1f
 
-#define DMA_RANGES_IDX 2
+#define DMA_RANGES_IDX 3
 
 #define PCIE_ECAM_BDF_SHIFT 12
 
@@ -189,6 +189,90 @@ struct pcie_brcmstb_data {
 	} regions[PCIE_REGION_MAX];
 	size_t bar_cnt;
 };
+
+bool pcie_probe(pcie_bdf_t bdf)
+{
+    struct pcie_bar bar;
+    bool found = false;
+
+    LOG_DBG("Probing PCIe device at BDF 0x%04x", bdf);
+
+    for (int i = 0; i < 6; i++) {
+        if (pcie_probe_mbar(bdf, i, &bar)) {
+            LOG_DBG("  Found MMIO BAR[%d]: phys=0x%08lx size=0x%lx", i,
+                    (unsigned long)bar.phys_addr, (unsigned long)bar.size);
+            found = true;
+        } else if (pcie_probe_iobar(bdf, i, &bar)) {
+            LOG_DBG("  Found I/O BAR[%d]: port=0x%08lx size=0x%lx", i,
+                    (unsigned long)bar.phys_addr, (unsigned long)bar.size);
+            found = true;
+        }
+    }
+
+    if (!found) {
+        LOG_WRN("  No valid BARs found for BDF 0x%04x", bdf);
+    }
+
+    return found;
+}
+
+#define PCIE_NODE_1 DT_NODELABEL(pcie1)  // or use correct label if it's pcie1, etc.
+#define PCIE_NODE_2 DT_NODELABEL(pcie2)  // or use correct label if it's pcie1, etc.
+
+void check_pcie_host_status(void)
+{
+    const struct device *pcie1 = DEVICE_DT_GET(PCIE_NODE_1);
+	const struct device *pcie2 = DEVICE_DT_GET(PCIE_NODE_2);
+
+    if (!device_is_ready(pcie1)) {
+        LOG_DBG("PCIe1 controller is NOT ready (disabled or failed init)\n");
+    } else {
+        LOG_DBG("PCIe1 controller is active and ready\n");
+    }
+
+    if (!device_is_ready(pcie2)) {
+        LOG_DBG("PCIe2 controller is NOT ready (disabled or failed init)\n");
+    } else {
+        LOG_DBG("PCIe2 controller is active and ready\n");
+    }
+}
+
+void check_tsn_pcie_status(void)
+{
+    bool tsn_eth_found = false;
+
+	for (int bus = 0; bus < 8; bus++)
+	{
+    	LOG_DBG("Probing PCIe bus %d...\n", bus);		
+		for (int dev = 0; dev < 32; dev++) {
+			uint32_t bdf = PCIE_BDF(bus, dev, 0); // bus 0, function 0
+
+			if (!pcie_probe(bdf)) {
+				continue;
+			}
+
+			uint32_t id = pcie_conf_read(bdf, PCIE_CONF_ID);
+			uint16_t vendor_id = id & 0xFFFF;
+			uint16_t device_id = (id >> 16) & 0xFFFF;
+
+			LOG_DBG("Found device at BDF 00:%02x.0, Vendor ID: 0x%04x, Device ID: 0x%04x\n",
+				dev, vendor_id, device_id);
+
+			// Replace with your real IDs
+			if (vendor_id == 0x10ee && device_id == 0x7024) {
+				tsn_eth_found = true;
+				LOG_DBG("TSN Ethernet XDMA device detected.\n");
+				break;
+			} 
+		}
+	}
+
+    if (!tsn_eth_found) {
+        LOG_DBG("Ethernet device not found.\n");
+    }	
+
+	check_pcie_host_status();
+}
 
 static inline uint32_t lower_32_bits(uint64_t val)
 {
@@ -276,7 +360,6 @@ static bool pcie_brcmstb_region_allocate_type(const struct device *dev, pcie_bdf
 	struct pcie_brcmstb_data *data = dev->data;
 	uintptr_t addr;
 
-	printk("bdf 0%x\n", bdf);
 	/* TODO: check bdf boundary */
 	addr = (((data->regions[type].bus_start + config->regs[PCIE_BDF_TO_BUS(bdf) + 1].addr +
 		  data->regions[type].allocation_offset) -
@@ -285,13 +368,14 @@ static bool pcie_brcmstb_region_allocate_type(const struct device *dev, pcie_bdf
 	       1;
 
 	if (addr + bar_size > data->regions[type].bus_start + data->regions[type].size) {
+		LOG_ERR("bus 0x%0x: base_size: %u", bdf, bar_size);
 		return false;
 	}
 
 	*bar_bus_addr = addr;
 	/* data->regions[type].allocation_offset = addr - data->regions[type].bus_start + bar_size;
 	 */
-	printk("alloc 0x%lx\n", addr);
+	LOG_INF("bus 0x%0x: alloc 0x%lx", bdf, addr);
 
 	return true;
 }
@@ -365,7 +449,7 @@ static bool pcie_brcmstb_region_translate(const struct device *dev, pcie_bdf_t b
 	type = pcie_brcmstb_determine_region_type(dev, mem, mem64);
 
 	*bar_addr = data->regions[type].phys_start + (bar_bus_addr - data->regions[type].bus_start);
-	printk("translate 0x%lx\n", *bar_addr);
+	LOG_INF("translate 0x%lx", *bar_addr);
 
 	return true;
 }
@@ -386,7 +470,12 @@ static int pcie_brcmstb_parse_regions(const struct device *dev)
 	int i;
 
 	for (i = 0; i < DMA_RANGES_IDX; i++) {
-		switch ((config->common->ranges[i].flags >> 24) & 0x03) {
+        uint32_t flags = (config->common->ranges[i].flags >> 24) & 0x03;
+        LOG_DBG("Parsing range %d: flags=0x%x, pcie_bus_addr=0x%lx, host_map_addr=0x%lx, map_length=0x%lx",
+               i, flags, config->common->ranges[i].pcie_bus_addr,
+               config->common->ranges[i].host_map_addr, config->common->ranges[i].map_length);
+
+		switch (flags) {
 		case 0x01:
 			type = PCIE_REGION_IO;
 			break;
@@ -482,6 +571,21 @@ static void pcie_brcmstb_set_outbound_win(const struct device *dev, uint8_t win,
 	sys_write32(tmp, data->cfg_addr + PCIE_MEM_WIN0_LIMIT_HI(win));
 }
 
+#define PCI_EXP_LNKCTL2        0x30
+#define PCI_EXP_LNKCAP         0x0c
+#define PCI_EXP_LNKSTA         0x12 // Added for Link Status Register
+#define PCI_EXP_RTCAP          0x10  /* Root Complex Capability Register */
+#define PCI_EXP_RTCTL          0x14  /* Root Complex Control Register */
+
+#define PCI_EXP_LNKCAP_SLS 0x00000F00  /* Supported Link Speeds */
+#define PCI_EXP_LNKCTL2_TLS 0x000F      /* Target Link Speed */
+#define PCI_EXP_LNKSTA_CLS  0x000F      /* Current Link Speed */
+#define PCI_EXP_LNKSTA_NLW  0x007F00    /* Negotiated Link Width */
+#define PCI_EXP_LNKSTA_DLLLA 0x00001000 /* Data Link Layer Active */
+#define PCI_EXP_RTCAP_CRSVIS 0x0010  /* Completion Received Support Visibility */
+#define PCI_EXP_RTCTL_CRSSVE 0x0001  /* Completion Received Snoop Visibility Enable */
+
+
 static int pcie_brcmstb_setup(const struct device *dev)
 {
 	const struct pcie_brcmstb_config *config = dev->config;
@@ -491,67 +595,177 @@ static int pcie_brcmstb_setup(const struct device *dev)
 
 	/* This block is for BCM2712 only */
 	pcie_brcmstb_munge_pll(dev);
+	
+	LOG_DBG("Reading PCIE_RC_PL_PHY_CTL_15 (offset: 0x%x)", PCIE_RC_PL_PHY_CTL_15);
 	tmp = sys_read32(data->cfg_addr + PCIE_RC_PL_PHY_CTL_15);
+	LOG_DBG("PCIE_RC_PL_PHY_CTL_15 value: 0x%x", tmp);
 	tmp &= ~PCIE_RC_PL_PHY_CTL_15_PM_CLK_PERIOD_MASK;
 	tmp |= PCIE_RC_PL_PHY_CTL_15_PM_CLK_PERIOD;
+	LOG_DBG("Writing PCIE_RC_PL_PHY_CTL_15 with value: 0x%x", tmp);	
 	sys_write32(tmp, data->cfg_addr + PCIE_RC_PL_PHY_CTL_15);
+	LOG_DBG("PCIE_RC_PL_PHY_CTL_15 after write: 0x%x", sys_read32(data->cfg_addr + PCIE_RC_PL_PHY_CTL_15));
 
+	LOG_DBG("Reading PCIE_MISC_MISC_CTRL (offset: 0x%x)", PCIE_MISC_MISC_CTRL);
 	tmp = sys_read32(data->cfg_addr + PCIE_MISC_MISC_CTRL);
+	LOG_DBG("PCIE_MISC_MISC_CTRL value: 0x%x", tmp);
 	tmp |= PCIE_MISC_MISC_CTRL_SCB_ACCESS_EN_MASK;
 	tmp |= PCIE_MISC_MISC_CTRL_CFG_READ_UR_MODE_MASK;
 	tmp &= ~PCIE_MISC_MISC_CTRL_MAX_BURST_SIZE_MASK;
 	tmp |= (BCM2712_BURST_SIZE << PCIE_MISC_MISC_CTRL_MAX_BURST_SIZE_LSB);
+	LOG_DBG("Writing PCIE_MISC_MISC_CTRL with value: 0x%x (SCB_ACCESS_EN, CFG_READ_UR_MODE, MAX_BURST_SIZE)", tmp);
 	sys_write32(tmp, data->cfg_addr + PCIE_MISC_MISC_CTRL);
+	LOG_DBG("PCIE_MISC_MISC_CTRL after write: 0x%x", sys_read32(data->cfg_addr + PCIE_MISC_MISC_CTRL));
 
 	uint64_t rc_bar2_offset = config->common->ranges[DMA_RANGES_IDX].host_map_addr -
 				  config->common->ranges[DMA_RANGES_IDX].pcie_bus_addr;
 	uint64_t rc_bar2_size = config->common->ranges[DMA_RANGES_IDX].map_length;
+    LOG_DBG("RC_BAR2 Offset: 0x%llx, Size: 0x%llx", rc_bar2_offset, rc_bar2_size);
 
+	LOG_DBG("Reading PCIE_MISC_RC_BAR2_CONFIG_LO (offset: 0x%x)", PCIE_MISC_RC_BAR2_CONFIG_LO);
 	tmp = lower_32_bits(rc_bar2_offset);
+    LOG_DBG("PCIE_MISC_RC_BAR2_CONFIG_LO value: 0x%x", tmp);	
 	tmp &= ~PCIE_MISC_RC_BAR2_CONFIG_LO_SIZE_MASK;
 	tmp |= encode_ibar_size(rc_bar2_size) << PCIE_MISC_RC_BAR2_CONFIG_LO_SIZE_LSB;
+    LOG_DBG("Writing PCIE_MISC_RC_BAR2_CONFIG_LO with value: 0x%x (size encoded)", tmp);	
 	sys_write32(tmp, data->cfg_addr + PCIE_MISC_RC_BAR2_CONFIG_LO);
-	sys_write32(upper_32_bits(rc_bar2_offset), data->cfg_addr + PCIE_MISC_RC_BAR2_CONFIG_HI);
+    LOG_DBG("PCIE_MISC_RC_BAR2_CONFIG_LO after write: 0x%x", sys_read32(data->cfg_addr + PCIE_MISC_RC_BAR2_CONFIG_LO));
 
+    LOG_DBG("Writing PCIE_MISC_RC_BAR2_CONFIG_HI (offset: 0x%x) with value: 0x%x (upper offset)",
+           PCIE_MISC_RC_BAR2_CONFIG_HI, upper_32_bits(rc_bar2_offset));	
+	sys_write32(upper_32_bits(rc_bar2_offset), data->cfg_addr + PCIE_MISC_RC_BAR2_CONFIG_HI);
+	LOG_DBG("PCIE_MISC_RC_BAR2_CONFIG_HI after write: 0x%x", sys_read32(data->cfg_addr + PCIE_MISC_RC_BAR2_CONFIG_HI));
+
+	LOG_DBG("Reading PCIE_MISC_UBUS_BAR2_CONFIG_REMAP (offset: 0x%x)", PCIE_MISC_UBUS_BAR2_CONFIG_REMAP);
 	tmp = sys_read32(data->cfg_addr + PCIE_MISC_UBUS_BAR2_CONFIG_REMAP);
+	LOG_DBG("PCIE_MISC_UBUS_BAR2_CONFIG_REMAP value: 0x%x", tmp);
 	tmp |= PCIE_MISC_UBUS_BAR2_CONFIG_REMAP_ACCESS_ENABLE_MASK;
+	LOG_DBG("Writing PCIE_MISC_UBUS_BAR2_CONFIG_REMAP with value: 0x%x (ACCESS_ENABLE)", tmp);
 	sys_write32(tmp, data->cfg_addr + PCIE_MISC_UBUS_BAR2_CONFIG_REMAP);
+	LOG_DBG("PCIE_MISC_UBUS_BAR2_CONFIG_REMAP after write: 0x%x", sys_read32(data->cfg_addr + PCIE_MISC_UBUS_BAR2_CONFIG_REMAP));
 
 	/* Set SCB Size */
+	LOG_DBG("Reading PCIE_MISC_MISC_CTRL (offset: 0x%x) for SCB size", PCIE_MISC_MISC_CTRL);
 	tmp = sys_read32(data->cfg_addr + PCIE_MISC_MISC_CTRL);
+	LOG_DBG("PCIE_MISC_MISC_CTRL value: 0x%x", tmp);
 	tmp &= ~PCIE_MISC_MISC_CTRL_SCB0_SIZE_MASK;
+    uint32_t scb_size_val = (ilog2(config->common->ranges[DMA_RANGES_IDX].map_length) - 15)
+                             << PCIE_MISC_MISC_CTRL_SCB0_SIZE_LSB;
+    LOG_DBG("Calculated SCB size value: 0x%x (size: 0x%lx, ilog2 - 15: %d, shift: %d)",
+           scb_size_val, config->common->ranges[DMA_RANGES_IDX].map_length,
+           ilog2(config->common->ranges[DMA_RANGES_IDX].map_length) - 15,
+           PCIE_MISC_MISC_CTRL_SCB0_SIZE_LSB);	
 	tmp |= (ilog2(config->common->ranges[DMA_RANGES_IDX].map_length) - 15)
 	       << PCIE_MISC_MISC_CTRL_SCB0_SIZE_LSB;
+	LOG_DBG("Writing PCIE_MISC_MISC_CTRL with value: 0x%x (SCB0_SIZE)", tmp);
 	sys_write32(tmp, data->cfg_addr + PCIE_MISC_MISC_CTRL);
+	LOG_DBG("PCIE_MISC_MISC_CTRL after write: 0x%x", sys_read32(data->cfg_addr + PCIE_MISC_MISC_CTRL));
 
+	LOG_DBG("Reading PCIE_MISC_UBUS_CTRL (offset: 0x%x)", PCIE_MISC_UBUS_CTRL);
 	tmp = sys_read32(data->cfg_addr + PCIE_MISC_UBUS_CTRL);
+	LOG_DBG("PCIE_MISC_UBUS_CTRL value: 0x%x", tmp);
 	tmp |= PCIE_MISC_UBUS_CTRL_UBUS_PCIE_REPLY_ERR_DIS_MASK;
 	tmp |= PCIE_MISC_UBUS_CTRL_UBUS_PCIE_REPLY_DECERR_DIS_MASK;
+	LOG_DBG("Writing PCIE_MISC_UBUS_CTRL with value: 0x%x (reply error/decerr disable)", tmp);
 	sys_write32(tmp, data->cfg_addr + PCIE_MISC_UBUS_CTRL);
+	LOG_DBG("PCIE_MISC_UBUS_CTRL after write: 0x%x", sys_read32(data->cfg_addr + PCIE_MISC_UBUS_CTRL));
+
+    LOG_DBG("Writing PCIE_MISC_AXI_READ_ERROR_DATA (offset: 0x%x) with value: 0x%x",
+           PCIE_MISC_AXI_READ_ERROR_DATA, 0xffffffff);	
 	sys_write32(0xffffffff, data->cfg_addr + PCIE_MISC_AXI_READ_ERROR_DATA);
+    LOG_DBG("PCIE_MISC_AXI_READ_ERROR_DATA after write: 0x%x", sys_read32(data->cfg_addr + PCIE_MISC_AXI_READ_ERROR_DATA));
 
 	/* Set timeouts */
+	LOG_DBG("Writing PCIE_MISC_UBUS_TIMEOUT (offset: 0x%x) with value: 0x%x",
+           (unsigned int) PCIE_MISC_UBUS_TIMEOUT, (unsigned int) BCM2712_UBUS_TIMEOUT_TICKS);
 	sys_write32(BCM2712_UBUS_TIMEOUT_TICKS, data->cfg_addr + PCIE_MISC_UBUS_TIMEOUT);
+	LOG_DBG("PCIE_MISC_UBUS_TIMEOUT after write: 0x%x", sys_read32(data->cfg_addr + PCIE_MISC_UBUS_TIMEOUT));
+
+	LOG_DBG("Writing PCIE_MISC_RC_CONFIG_RETRY_TIMEOUT (offset: 0x%x) with value: 0x%x",
+           (unsigned int) PCIE_MISC_RC_CONFIG_RETRY_TIMEOUT, (unsigned int) BCM2712_RC_CONFIG_RETRY_TIMEOUT_TICKS);
 	sys_write32(BCM2712_RC_CONFIG_RETRY_TIMEOUT_TICKS,
 		    data->cfg_addr + PCIE_MISC_RC_CONFIG_RETRY_TIMEOUT);
+	LOG_DBG("PCIE_MISC_RC_CONFIG_RETRY_TIMEOUT after write: 0x%x",
+           sys_read32(data->cfg_addr + PCIE_MISC_RC_CONFIG_RETRY_TIMEOUT));			
 
+	LOG_DBG("Reading PCIE_MISC_RC_BAR1_CONFIG_LO (offset: 0x%x)", PCIE_MISC_RC_BAR1_CONFIG_LO);
 	tmp = sys_read32(data->cfg_addr + PCIE_MISC_RC_BAR1_CONFIG_LO);
+	LOG_DBG("PCIE_MISC_RC_BAR1_CONFIG_LO value: 0x%x", tmp);
 	tmp &= ~PCIE_MISC_RC_BAR1_CONFIG_LO_SIZE_MASK;
+	LOG_DBG("Writing PCIE_MISC_RC_BAR1_CONFIG_LO with value: 0x%x (size mask cleared)", tmp);
 	sys_write32(tmp, data->cfg_addr + PCIE_MISC_RC_BAR1_CONFIG_LO);
+	LOG_DBG("PCIE_MISC_RC_BAR1_CONFIG_LO after write: 0x%x", sys_read32(data->cfg_addr + PCIE_MISC_RC_BAR1_CONFIG_LO));
 
+	LOG_DBG("Reading PCIE_MISC_RC_BAR3_CONFIG_LO (offset: 0x%x)", PCIE_MISC_RC_BAR3_CONFIG_LO);
 	tmp = sys_read32(data->cfg_addr + PCIE_MISC_RC_BAR3_CONFIG_LO);
+	LOG_DBG("PCIE_MISC_RC_BAR3_CONFIG_LO value: 0x%x", tmp);
 	tmp &= ~PCIE_MISC_RC_BAR3_CONFIG_LO_SIZE_MASK;
+	LOG_DBG("Writing PCIE_MISC_RC_BAR3_CONFIG_LO with value: 0x%x (size mask cleared)", tmp);
 	sys_write32(tmp, data->cfg_addr + PCIE_MISC_RC_BAR3_CONFIG_LO);
+	LOG_DBG("PCIE_MISC_RC_BAR3_CONFIG_LO after write: 0x%x", sys_read32(data->cfg_addr + PCIE_MISC_RC_BAR3_CONFIG_LO));
+
+    // 1. Reset Sequence
+    // Assert PERST#
+    LOG_INF("Asserting PERST#");
+    // Assuming pcie->cfg->perst_set is available in your Zephyr environment
+    // If not, you'll need to use the appropriate board-specific GPIO control
+    // to assert the reset.
+    // ret = pcie->cfg->perst_set(pcie, 1); // Assert reset
+    // if (ret) {
+    //     LOG_ERR("Failed to assert PERST#");
+    //     return ret;
+    // }
+    sys_write32(1, data->cfg_addr + 0x108); // Replace 0xXXXX with actual register offset
+    k_sleep(K_MSEC(1)); // 1ms delay - adjust as needed
+
+    // Deassert PERST#
+    LOG_INF("Deasserting PERST#");
+    // ret = pcie->cfg->perst_set(pcie, 0); // Deassert reset
+    // if (ret) {
+    //     LOG_ERR("Failed to deassert PERST#");
+    //     return ret;
+    // }
+    sys_write32(0, data->cfg_addr + 0x108); // Replace 0xXXXX with actual register offset
+
+    k_sleep(K_MSEC(100)); // 100ms delay after deassertion - adjust as needed
+
+     // 2. Wait for Link Up
+    LOG_INF("Waiting for link to come up...");
+    for (int i = 0; i < 20; i++) { // Retry for a maximum of 20 times (5ms * 20 = 100ms)
+        k_sleep(K_MSEC(5));
+        tmp16 = sys_read16(data->cfg_addr + BRCM_PCIE_CAP_REGS + PCI_EXP_LNKSTA);
+        LOG_INF("PCI_EXP_LNKSTA value: 0x%x", tmp16);
+        if (tmp16 & PCI_EXP_LNKSTA_DLLLA) {
+            LOG_INF("Data Link Layer is active.");
+            break;
+        }
+    }
+
+    if (!(tmp16 & PCI_EXP_LNKSTA_DLLLA)) {
+        LOG_ERR("Linkup timeout.");
+        return -ENODEV;
+    }	
 
 	/* Set gen to 2 */
+	LOG_DBG("Reading PCI_EXP_LNKCTL2 (offset: 0x%x) in BRCM_PCIE_CAP_REGS (offset: 0x%x)",
+           PCI_EXP_LNKCTL2, BRCM_PCIE_CAP_REGS);
 	tmp16 = sys_read16(data->cfg_addr + BRCM_PCIE_CAP_REGS + PCI_EXP_LNKCTL2);
+	LOG_DBG("Initial PCI_EXP_LNKCTL2 value: 0x%x", tmp16);
+
+	LOG_DBG("Reading PCI_EXP_LNKCAP (offset: 0x%x) in BRCM_PCIE_CAP_REGS (offset: 0x%x)",
+           PCI_EXP_LNKCAP, BRCM_PCIE_CAP_REGS);
 	tmp = sys_read32(data->cfg_addr + BRCM_PCIE_CAP_REGS + PCI_EXP_LNKCAP);
+	LOG_DBG("Initial PCI_EXP_LNKCAP value: 0x%x", tmp);
 	tmp &= ~PCI_EXP_LNKCAP_SLS;
 	tmp |= 0x2;
+	LOG_DBG("Writing PCI_EXP_LNKCAP with value: 0x%x (SLS set to 2)", tmp);
 	sys_write32(tmp, data->cfg_addr + BRCM_PCIE_CAP_REGS + PCI_EXP_LNKCAP);
+	LOG_DBG("PCI_EXP_LNKCAP after write: 0x%x", sys_read32(data->cfg_addr + BRCM_PCIE_CAP_REGS + PCI_EXP_LNKCAP));
+
 	tmp16 &= ~0xf;
 	tmp16 |= 0x2;
+	LOG_DBG("Writing PCI_EXP_LNKCTL2 with value: 0x%x (Target Link Speed set to 2)", tmp16);
 	sys_write16(tmp16, data->cfg_addr + BRCM_PCIE_CAP_REGS + PCI_EXP_LNKCTL2);
+	LOG_DBG("PCI_EXP_LNKCTL2 after write: 0x%x", sys_read16(data->cfg_addr + BRCM_PCIE_CAP_REGS + PCI_EXP_LNKCTL2));
 
 	tmp = sys_read32(data->cfg_addr + PCIE_RC_CFG_PRIV1_ID_VAL3);
 	tmp &= ~PCIE_RC_CFG_PRIV1_ID_VAL3_CLASS_CODE_MASK;
@@ -564,11 +778,28 @@ static int pcie_brcmstb_setup(const struct device *dev)
 	       << PCIE_RC_CFG_VENDOR_VENDOR_SPECIFIC_REG1_ENDIAN_MODE_BAR2_LSB;
 	sys_write32(tmp, data->cfg_addr + PCIE_RC_CFG_VENDOR_VENDOR_SPECIFIC_REG1);
 
+
+#define PCI_EXP_LNKSTA_OFFSET 0x12
+
+	LOG_DBG("Reading PCI_EXP_LNKSTA (offset: 0x%x) in BRCM_PCIE_CAP_REGS (offset: 0x%x)",
+	       PCI_EXP_LNKSTA_OFFSET, BRCM_PCIE_CAP_REGS);
+	uint16_t lnksta = sys_read16(data->cfg_addr + BRCM_PCIE_CAP_REGS + PCI_EXP_LNKSTA_OFFSET);
+	LOG_DBG("PCI_EXP_LNKSTA value: 0x%x", lnksta);
+	if (lnksta & PCI_EXP_LNKSTA_DLLLA) {
+		LOG_INF("Data Link Layer is active.");
+	} else {
+		LOG_ERR("Data Link Layer is inactive.");
+	}
+
 	return 0;
 }
 
+
+
 static int pcie_brcmstb_init(const struct device *dev)
 {
+	LOG_INF("pcie_brcmstb_init\n");
+
 	const struct pcie_brcmstb_config *config = dev->config;
 	struct pcie_brcmstb_data *data = dev->data;
 	uint32_t tmp;
@@ -576,11 +807,13 @@ static int pcie_brcmstb_init(const struct device *dev)
 
 	if (config->common->ranges_count < DMA_RANGES_IDX) {
 		/* Workaround since macros for `dma-ranges` property is not available */
+		LOG_ERR("pcie_brcmstb_init `dma-ranges` property is not available\n");
 		return -EINVAL;
 	}
 
 	ret = pcie_brcmstb_parse_regions(dev);
 	if (ret != 0) {
+		LOG_ERR("pcie_brcmstb_init pcie_brcmstb_parse_regions error\n");
 		return ret;
 	}
 
@@ -625,11 +858,12 @@ static int pcie_brcmstb_init(const struct device *dev)
 	mm_reg_t test_dma_addr;
 
 	device_map(&test_dma_addr, 0x1b08000000, 0x4000, K_MEM_CACHE_NONE);
-	printk("H2C 0x%x\n", sys_read32(test_dma_addr));
-	printk("C2H 0x%x\n", sys_read32(test_dma_addr + 0x1000));
-
+	LOG_INF("H2C 0x%x", sys_read32(test_dma_addr));
+	LOG_INF("C2H 0x%x", sys_read32(test_dma_addr + 0x1000));	
 	return 0;
 }
+
+#define PCIe_BRCMSTB_INIT_PRIO 97 // Just after early kernel subsystems
 
 /* TODO: POST_KERNEL is set to use printk, revert this after the development is done */
 #define PCIE_BRCMSTB_INIT(n)                                                                       \
@@ -653,10 +887,12 @@ static int pcie_brcmstb_init(const struct device *dev)
 				 DT_REG_SIZE_BY_IDX(DT_DRV_INST(n), 1)},                           \
 				{DT_REG_ADDR_BY_IDX(DT_DRV_INST(n), 2),                            \
 				 DT_REG_SIZE_BY_IDX(DT_DRV_INST(n), 2)},                           \
+				{DT_REG_ADDR_BY_IDX(DT_DRV_INST(n), 3),                            \
+				 DT_REG_SIZE_BY_IDX(DT_DRV_INST(n), 3)},                            \
 			},                                                                         \
 	};                                                                                         \
                                                                                                    \
 	DEVICE_DT_INST_DEFINE(n, pcie_brcmstb_init, NULL, &pcie_brcmstb_data_##n,                  \
-			      &pcie_brcmstb_cfg_##n, POST_KERNEL, 97, &pcie_brcmstb_api);
+			      &pcie_brcmstb_cfg_##n, POST_KERNEL, PCIe_BRCMSTB_INIT_PRIO, &pcie_brcmstb_api);
 
 DT_INST_FOREACH_STATUS_OKAY(PCIE_BRCMSTB_INIT)

--- a/drivers/pcie/controller/pcie_brcmstb.c
+++ b/drivers/pcie/controller/pcie_brcmstb.c
@@ -244,7 +244,7 @@ void check_tsn_pcie_status(void)
 	for (int bus = 0; bus < 8; bus++) {
 		LOG_DBG("Probing PCIe bus %d...\n", bus);
 		for (int dev = 0; dev < 32; dev++) {
-			uint32_t bdf = PCIE_BDF(bus, dev, 0); // bus 0, function 0
+			uint32_t bdf = PCIE_BDF(bus, dev, 0);
 
 			if (!pcie_probe(bdf)) {
 				continue;
@@ -254,11 +254,9 @@ void check_tsn_pcie_status(void)
 			uint16_t vendor_id = id & 0xFFFF;
 			uint16_t device_id = (id >> 16) & 0xFFFF;
 
-			LOG_DBG("Found device at BDF 00:%02x.0, Vendor ID: 0x%04x, Device ID: "
-				"0x%04x\n",
+			LOG_DBG("Found device at BDF 00:%02x.0, Vendor ID: 0x%04x, Device ID: 0x%04x\n",
 				dev, vendor_id, device_id);
 
-			// Replace with your real IDs
 			if (vendor_id == 0x10ee && device_id == 0x7024) {
 				tsn_eth_found = true;
 				LOG_DBG("TSN Ethernet XDMA device detected.\n");
@@ -575,7 +573,7 @@ static void pcie_brcmstb_set_outbound_win(const struct device *dev, uint8_t win,
 
 #define PCI_EXP_LNKCTL2 0x30
 #define PCI_EXP_LNKCAP  0x0c
-#define PCI_EXP_LNKSTA  0x12 // Added for Link Status Register
+#define PCI_EXP_LNKSTA  0x12 /* Added for Link Status Register */
 #define PCI_EXP_RTCAP   0x10 /* Root Complex Capability Register */
 #define PCI_EXP_RTCTL   0x14 /* Root Complex Control Register */
 

--- a/drivers/pcie/controller/pcie_brcmstb.c
+++ b/drivers/pcie/controller/pcie_brcmstb.c
@@ -471,9 +471,15 @@ static int pcie_brcmstb_parse_regions(const struct device *dev)
 
 	for (i = 0; i < DMA_RANGES_IDX; i++) {
 		uint32_t flags = (config->common->ranges[i].flags >> 24) & 0x03;
-		LOG_DBG("Parsing range %d: flags=0x%x, pcie_bus_addr=0x%lx, host_map_addr=0x%lx, "
+
+		LOG_DBG("Parsing range %d: "
+			"flags=0x%x, "
+			"pcie_bus_addr=0x%lx, "
+			"host_map_addr=0x%lx, "
 			"map_length=0x%lx",
-			i, flags, config->common->ranges[i].pcie_bus_addr,
+			i,
+			flags,
+			config->common->ranges[i].pcie_bus_addr,
 			config->common->ranges[i].host_map_addr,
 			config->common->ranges[i].map_length);
 

--- a/drivers/pcie/controller/pcie_brcmstb.c
+++ b/drivers/pcie/controller/pcie_brcmstb.c
@@ -254,7 +254,9 @@ void check_tsn_pcie_status(void)
 			uint16_t vendor_id = id & 0xFFFF;
 			uint16_t device_id = (id >> 16) & 0xFFFF;
 
-			LOG_DBG("Found device at BDF 00:%02x.0, Vendor ID: 0x%04x, Device ID: 0x%04x\n",
+			LOG_DBG("Found device at BDF 00:%02x.0, "
+				"Vendor ID: 0x%04x, "
+				"Device ID: 0x%04x\n",
 				dev, vendor_id, device_id);
 
 			if (vendor_id == 0x10ee && device_id == 0x7024) {

--- a/drivers/pcie/controller/pcie_brcmstb.c
+++ b/drivers/pcie/controller/pcie_brcmstb.c
@@ -720,34 +720,34 @@ static int pcie_brcmstb_setup(const struct device *dev)
 	LOG_DBG("PCIE_MISC_RC_BAR3_CONFIG_LO after write: 0x%x",
 		sys_read32(data->cfg_addr + PCIE_MISC_RC_BAR3_CONFIG_LO));
 
-	// 1. Reset Sequence
-	// Assert PERST#
+	/* 1. Reset Sequence */ 
+	/* Assert PERST# */ 
 	LOG_INF("Asserting PERST#");
-	// Assuming pcie->cfg->perst_set is available in your Zephyr environment
-	// If not, you'll need to use the appropriate board-specific GPIO control
-	// to assert the reset.
-	// ret = pcie->cfg->perst_set(pcie, 1); // Assert reset
-	// if (ret) {
-	//     LOG_ERR("Failed to assert PERST#");
-	//     return ret;
-	// }
-	sys_write32(1, data->cfg_addr + 0x108); // Replace 0xXXXX with actual register offset
-	k_sleep(K_MSEC(1));                     // 1ms delay - adjust as needed
+	/* Assuming pcie->cfg->perst_set is available in your Zephyr environment */ 
+	/* If not, you'll need to use the appropriate board-specific GPIO control */ 
+	/* to assert the reset. */ 
+	/* ret = pcie->cfg->perst_set(pcie, 1); // Assert reset */
+	/* if (ret) { */
+	/*     LOG_ERR("Failed to assert PERST#"); */
+	/*     return ret; */
+	/* } */
+	sys_write32(1, data->cfg_addr + 0x108); /* Replace 0xXXXX with actual register offset */
+	k_sleep(K_MSEC(1));                     /* 1ms delay - adjust as needed */
 
-	// Deassert PERST#
+	/* Deassert PERST# */
 	LOG_INF("Deasserting PERST#");
-	// ret = pcie->cfg->perst_set(pcie, 0); // Deassert reset
-	// if (ret) {
-	//     LOG_ERR("Failed to deassert PERST#");
-	//     return ret;
-	// }
-	sys_write32(0, data->cfg_addr + 0x108); // Replace 0xXXXX with actual register offset
+	/* ret = pcie->cfg->perst_set(pcie, 0); // Deassert reset */
+	/* if (ret) { */
+	/*     LOG_ERR("Failed to deassert PERST#"); */
+	/*     return ret; */
+	/* } */
+	sys_write32(0, data->cfg_addr + 0x108); /* Replace 0xXXXX with actual register offset */
 
-	k_sleep(K_MSEC(100)); // 100ms delay after deassertion - adjust as needed
+	k_sleep(K_MSEC(100)); /* 100ms delay after deassertion - adjust as needed */
 
-	// 2. Wait for Link Up
+	/* 2. Wait for Link Up */
 	LOG_INF("Waiting for link to come up...");
-	for (int i = 0; i < 20; i++) { // Retry for a maximum of 20 times (5ms * 20 = 100ms)
+	for (int i = 0; i < 20; i++) { /* Retry for a maximum of 20 times (5ms * 20 = 100ms) */
 		k_sleep(K_MSEC(5));
 		tmp16 = sys_read16(data->cfg_addr + BRCM_PCIE_CAP_REGS + PCI_EXP_LNKSTA);
 		LOG_INF("PCI_EXP_LNKSTA value: 0x%x", tmp16);
@@ -801,8 +801,10 @@ static int pcie_brcmstb_setup(const struct device *dev)
 
 	LOG_DBG("Reading PCI_EXP_LNKSTA (offset: 0x%x) in BRCM_PCIE_CAP_REGS (offset: 0x%x)",
 		PCI_EXP_LNKSTA_OFFSET, BRCM_PCIE_CAP_REGS);
+
 	uint16_t lnksta = sys_read16(data->cfg_addr + BRCM_PCIE_CAP_REGS + PCI_EXP_LNKSTA_OFFSET);
-	LOG_DBG("PCI_EXP_LNKSTA value: 0x%x", lnksta);
+
+	LOG_DBG("PCI_EXP_LNKSTA value: 0x%x", lnksta);	
 	if (lnksta & PCI_EXP_LNKSTA_DLLLA) {
 		LOG_INF("Data Link Layer is active.");
 	} else {
@@ -879,7 +881,7 @@ static int pcie_brcmstb_init(const struct device *dev)
 	return 0;
 }
 
-#define PCIe_BRCMSTB_INIT_PRIO 97 // Just after early kernel subsystems
+#define PCIe_BRCMSTB_INIT_PRIO 97  /* Just after early kernel subsystems */
 
 /* TODO: POST_KERNEL is set to use printk, revert this after the development is done */
 #define PCIE_BRCMSTB_INIT(n)                                                                       \

--- a/drivers/pcie/controller/pcie_brcmstb.c
+++ b/drivers/pcie/controller/pcie_brcmstb.c
@@ -192,58 +192,57 @@ struct pcie_brcmstb_data {
 
 bool pcie_probe(pcie_bdf_t bdf)
 {
-    struct pcie_bar bar;
-    bool found = false;
+	struct pcie_bar bar;
+	bool found = false;
 
-    LOG_DBG("Probing PCIe device at BDF 0x%04x", bdf);
+	LOG_DBG("Probing PCIe device at BDF 0x%04x", bdf);
 
-    for (int i = 0; i < 6; i++) {
-        if (pcie_probe_mbar(bdf, i, &bar)) {
-            LOG_DBG("  Found MMIO BAR[%d]: phys=0x%08lx size=0x%lx", i,
-                    (unsigned long)bar.phys_addr, (unsigned long)bar.size);
-            found = true;
-        } else if (pcie_probe_iobar(bdf, i, &bar)) {
-            LOG_DBG("  Found I/O BAR[%d]: port=0x%08lx size=0x%lx", i,
-                    (unsigned long)bar.phys_addr, (unsigned long)bar.size);
-            found = true;
-        }
-    }
+	for (int i = 0; i < 6; i++) {
+		if (pcie_probe_mbar(bdf, i, &bar)) {
+			LOG_DBG("  Found MMIO BAR[%d]: phys=0x%08lx size=0x%lx", i,
+				(unsigned long)bar.phys_addr, (unsigned long)bar.size);
+			found = true;
+		} else if (pcie_probe_iobar(bdf, i, &bar)) {
+			LOG_DBG("  Found I/O BAR[%d]: port=0x%08lx size=0x%lx", i,
+				(unsigned long)bar.phys_addr, (unsigned long)bar.size);
+			found = true;
+		}
+	}
 
-    if (!found) {
-        LOG_WRN("  No valid BARs found for BDF 0x%04x", bdf);
-    }
+	if (!found) {
+		LOG_WRN("  No valid BARs found for BDF 0x%04x", bdf);
+	}
 
-    return found;
+	return found;
 }
 
-#define PCIE_NODE_1 DT_NODELABEL(pcie1)  // or use correct label if it's pcie1, etc.
-#define PCIE_NODE_2 DT_NODELABEL(pcie2)  // or use correct label if it's pcie1, etc.
+#define PCIE_NODE_1 DT_NODELABEL(pcie1) // or use correct label if it's pcie1, etc.
+#define PCIE_NODE_2 DT_NODELABEL(pcie2) // or use correct label if it's pcie1, etc.
 
 void check_pcie_host_status(void)
 {
-    const struct device *pcie1 = DEVICE_DT_GET(PCIE_NODE_1);
+	const struct device *pcie1 = DEVICE_DT_GET(PCIE_NODE_1);
 	const struct device *pcie2 = DEVICE_DT_GET(PCIE_NODE_2);
 
-    if (!device_is_ready(pcie1)) {
-        LOG_DBG("PCIe1 controller is NOT ready (disabled or failed init)\n");
-    } else {
-        LOG_DBG("PCIe1 controller is active and ready\n");
-    }
+	if (!device_is_ready(pcie1)) {
+		LOG_DBG("PCIe1 controller is NOT ready (disabled or failed init)\n");
+	} else {
+		LOG_DBG("PCIe1 controller is active and ready\n");
+	}
 
-    if (!device_is_ready(pcie2)) {
-        LOG_DBG("PCIe2 controller is NOT ready (disabled or failed init)\n");
-    } else {
-        LOG_DBG("PCIe2 controller is active and ready\n");
-    }
+	if (!device_is_ready(pcie2)) {
+		LOG_DBG("PCIe2 controller is NOT ready (disabled or failed init)\n");
+	} else {
+		LOG_DBG("PCIe2 controller is active and ready\n");
+	}
 }
 
 void check_tsn_pcie_status(void)
 {
-    bool tsn_eth_found = false;
+	bool tsn_eth_found = false;
 
-	for (int bus = 0; bus < 8; bus++)
-	{
-    	LOG_DBG("Probing PCIe bus %d...\n", bus);		
+	for (int bus = 0; bus < 8; bus++) {
+		LOG_DBG("Probing PCIe bus %d...\n", bus);
 		for (int dev = 0; dev < 32; dev++) {
 			uint32_t bdf = PCIE_BDF(bus, dev, 0); // bus 0, function 0
 
@@ -255,7 +254,8 @@ void check_tsn_pcie_status(void)
 			uint16_t vendor_id = id & 0xFFFF;
 			uint16_t device_id = (id >> 16) & 0xFFFF;
 
-			LOG_DBG("Found device at BDF 00:%02x.0, Vendor ID: 0x%04x, Device ID: 0x%04x\n",
+			LOG_DBG("Found device at BDF 00:%02x.0, Vendor ID: 0x%04x, Device ID: "
+				"0x%04x\n",
 				dev, vendor_id, device_id);
 
 			// Replace with your real IDs
@@ -263,13 +263,13 @@ void check_tsn_pcie_status(void)
 				tsn_eth_found = true;
 				LOG_DBG("TSN Ethernet XDMA device detected.\n");
 				break;
-			} 
+			}
 		}
 	}
 
-    if (!tsn_eth_found) {
-        LOG_DBG("Ethernet device not found.\n");
-    }	
+	if (!tsn_eth_found) {
+		LOG_DBG("Ethernet device not found.\n");
+	}
 
 	check_pcie_host_status();
 }
@@ -470,10 +470,12 @@ static int pcie_brcmstb_parse_regions(const struct device *dev)
 	int i;
 
 	for (i = 0; i < DMA_RANGES_IDX; i++) {
-        uint32_t flags = (config->common->ranges[i].flags >> 24) & 0x03;
-        LOG_DBG("Parsing range %d: flags=0x%x, pcie_bus_addr=0x%lx, host_map_addr=0x%lx, map_length=0x%lx",
-               i, flags, config->common->ranges[i].pcie_bus_addr,
-               config->common->ranges[i].host_map_addr, config->common->ranges[i].map_length);
+		uint32_t flags = (config->common->ranges[i].flags >> 24) & 0x03;
+		LOG_DBG("Parsing range %d: flags=0x%x, pcie_bus_addr=0x%lx, host_map_addr=0x%lx, "
+			"map_length=0x%lx",
+			i, flags, config->common->ranges[i].pcie_bus_addr,
+			config->common->ranges[i].host_map_addr,
+			config->common->ranges[i].map_length);
 
 		switch (flags) {
 		case 0x01:
@@ -571,20 +573,19 @@ static void pcie_brcmstb_set_outbound_win(const struct device *dev, uint8_t win,
 	sys_write32(tmp, data->cfg_addr + PCIE_MEM_WIN0_LIMIT_HI(win));
 }
 
-#define PCI_EXP_LNKCTL2        0x30
-#define PCI_EXP_LNKCAP         0x0c
-#define PCI_EXP_LNKSTA         0x12 // Added for Link Status Register
-#define PCI_EXP_RTCAP          0x10  /* Root Complex Capability Register */
-#define PCI_EXP_RTCTL          0x14  /* Root Complex Control Register */
+#define PCI_EXP_LNKCTL2 0x30
+#define PCI_EXP_LNKCAP  0x0c
+#define PCI_EXP_LNKSTA  0x12 // Added for Link Status Register
+#define PCI_EXP_RTCAP   0x10 /* Root Complex Capability Register */
+#define PCI_EXP_RTCTL   0x14 /* Root Complex Control Register */
 
-#define PCI_EXP_LNKCAP_SLS 0x00000F00  /* Supported Link Speeds */
-#define PCI_EXP_LNKCTL2_TLS 0x000F      /* Target Link Speed */
-#define PCI_EXP_LNKSTA_CLS  0x000F      /* Current Link Speed */
-#define PCI_EXP_LNKSTA_NLW  0x007F00    /* Negotiated Link Width */
+#define PCI_EXP_LNKCAP_SLS   0x00000F00 /* Supported Link Speeds */
+#define PCI_EXP_LNKCTL2_TLS  0x000F     /* Target Link Speed */
+#define PCI_EXP_LNKSTA_CLS   0x000F     /* Current Link Speed */
+#define PCI_EXP_LNKSTA_NLW   0x007F00   /* Negotiated Link Width */
 #define PCI_EXP_LNKSTA_DLLLA 0x00001000 /* Data Link Layer Active */
-#define PCI_EXP_RTCAP_CRSVIS 0x0010  /* Completion Received Support Visibility */
-#define PCI_EXP_RTCTL_CRSSVE 0x0001  /* Completion Received Snoop Visibility Enable */
-
+#define PCI_EXP_RTCAP_CRSVIS 0x0010     /* Completion Received Support Visibility */
+#define PCI_EXP_RTCTL_CRSSVE 0x0001     /* Completion Received Snoop Visibility Enable */
 
 static int pcie_brcmstb_setup(const struct device *dev)
 {
@@ -595,15 +596,16 @@ static int pcie_brcmstb_setup(const struct device *dev)
 
 	/* This block is for BCM2712 only */
 	pcie_brcmstb_munge_pll(dev);
-	
+
 	LOG_DBG("Reading PCIE_RC_PL_PHY_CTL_15 (offset: 0x%x)", PCIE_RC_PL_PHY_CTL_15);
 	tmp = sys_read32(data->cfg_addr + PCIE_RC_PL_PHY_CTL_15);
 	LOG_DBG("PCIE_RC_PL_PHY_CTL_15 value: 0x%x", tmp);
 	tmp &= ~PCIE_RC_PL_PHY_CTL_15_PM_CLK_PERIOD_MASK;
 	tmp |= PCIE_RC_PL_PHY_CTL_15_PM_CLK_PERIOD;
-	LOG_DBG("Writing PCIE_RC_PL_PHY_CTL_15 with value: 0x%x", tmp);	
+	LOG_DBG("Writing PCIE_RC_PL_PHY_CTL_15 with value: 0x%x", tmp);
 	sys_write32(tmp, data->cfg_addr + PCIE_RC_PL_PHY_CTL_15);
-	LOG_DBG("PCIE_RC_PL_PHY_CTL_15 after write: 0x%x", sys_read32(data->cfg_addr + PCIE_RC_PL_PHY_CTL_15));
+	LOG_DBG("PCIE_RC_PL_PHY_CTL_15 after write: 0x%x",
+		sys_read32(data->cfg_addr + PCIE_RC_PL_PHY_CTL_15));
 
 	LOG_DBG("Reading PCIE_MISC_MISC_CTRL (offset: 0x%x)", PCIE_MISC_MISC_CTRL);
 	tmp = sys_read32(data->cfg_addr + PCIE_MISC_MISC_CTRL);
@@ -612,53 +614,62 @@ static int pcie_brcmstb_setup(const struct device *dev)
 	tmp |= PCIE_MISC_MISC_CTRL_CFG_READ_UR_MODE_MASK;
 	tmp &= ~PCIE_MISC_MISC_CTRL_MAX_BURST_SIZE_MASK;
 	tmp |= (BCM2712_BURST_SIZE << PCIE_MISC_MISC_CTRL_MAX_BURST_SIZE_LSB);
-	LOG_DBG("Writing PCIE_MISC_MISC_CTRL with value: 0x%x (SCB_ACCESS_EN, CFG_READ_UR_MODE, MAX_BURST_SIZE)", tmp);
+	LOG_DBG("Writing PCIE_MISC_MISC_CTRL with value: 0x%x (SCB_ACCESS_EN, CFG_READ_UR_MODE, "
+		"MAX_BURST_SIZE)",
+		tmp);
 	sys_write32(tmp, data->cfg_addr + PCIE_MISC_MISC_CTRL);
-	LOG_DBG("PCIE_MISC_MISC_CTRL after write: 0x%x", sys_read32(data->cfg_addr + PCIE_MISC_MISC_CTRL));
+	LOG_DBG("PCIE_MISC_MISC_CTRL after write: 0x%x",
+		sys_read32(data->cfg_addr + PCIE_MISC_MISC_CTRL));
 
 	uint64_t rc_bar2_offset = config->common->ranges[DMA_RANGES_IDX].host_map_addr -
 				  config->common->ranges[DMA_RANGES_IDX].pcie_bus_addr;
 	uint64_t rc_bar2_size = config->common->ranges[DMA_RANGES_IDX].map_length;
-    LOG_DBG("RC_BAR2 Offset: 0x%llx, Size: 0x%llx", rc_bar2_offset, rc_bar2_size);
+	LOG_DBG("RC_BAR2 Offset: 0x%llx, Size: 0x%llx", rc_bar2_offset, rc_bar2_size);
 
 	LOG_DBG("Reading PCIE_MISC_RC_BAR2_CONFIG_LO (offset: 0x%x)", PCIE_MISC_RC_BAR2_CONFIG_LO);
 	tmp = lower_32_bits(rc_bar2_offset);
-    LOG_DBG("PCIE_MISC_RC_BAR2_CONFIG_LO value: 0x%x", tmp);	
+	LOG_DBG("PCIE_MISC_RC_BAR2_CONFIG_LO value: 0x%x", tmp);
 	tmp &= ~PCIE_MISC_RC_BAR2_CONFIG_LO_SIZE_MASK;
 	tmp |= encode_ibar_size(rc_bar2_size) << PCIE_MISC_RC_BAR2_CONFIG_LO_SIZE_LSB;
-    LOG_DBG("Writing PCIE_MISC_RC_BAR2_CONFIG_LO with value: 0x%x (size encoded)", tmp);	
+	LOG_DBG("Writing PCIE_MISC_RC_BAR2_CONFIG_LO with value: 0x%x (size encoded)", tmp);
 	sys_write32(tmp, data->cfg_addr + PCIE_MISC_RC_BAR2_CONFIG_LO);
-    LOG_DBG("PCIE_MISC_RC_BAR2_CONFIG_LO after write: 0x%x", sys_read32(data->cfg_addr + PCIE_MISC_RC_BAR2_CONFIG_LO));
+	LOG_DBG("PCIE_MISC_RC_BAR2_CONFIG_LO after write: 0x%x",
+		sys_read32(data->cfg_addr + PCIE_MISC_RC_BAR2_CONFIG_LO));
 
-    LOG_DBG("Writing PCIE_MISC_RC_BAR2_CONFIG_HI (offset: 0x%x) with value: 0x%x (upper offset)",
-           PCIE_MISC_RC_BAR2_CONFIG_HI, upper_32_bits(rc_bar2_offset));	
+	LOG_DBG("Writing PCIE_MISC_RC_BAR2_CONFIG_HI (offset: 0x%x) with value: 0x%x (upper "
+		"offset)",
+		PCIE_MISC_RC_BAR2_CONFIG_HI, upper_32_bits(rc_bar2_offset));
 	sys_write32(upper_32_bits(rc_bar2_offset), data->cfg_addr + PCIE_MISC_RC_BAR2_CONFIG_HI);
-	LOG_DBG("PCIE_MISC_RC_BAR2_CONFIG_HI after write: 0x%x", sys_read32(data->cfg_addr + PCIE_MISC_RC_BAR2_CONFIG_HI));
+	LOG_DBG("PCIE_MISC_RC_BAR2_CONFIG_HI after write: 0x%x",
+		sys_read32(data->cfg_addr + PCIE_MISC_RC_BAR2_CONFIG_HI));
 
-	LOG_DBG("Reading PCIE_MISC_UBUS_BAR2_CONFIG_REMAP (offset: 0x%x)", PCIE_MISC_UBUS_BAR2_CONFIG_REMAP);
+	LOG_DBG("Reading PCIE_MISC_UBUS_BAR2_CONFIG_REMAP (offset: 0x%x)",
+		PCIE_MISC_UBUS_BAR2_CONFIG_REMAP);
 	tmp = sys_read32(data->cfg_addr + PCIE_MISC_UBUS_BAR2_CONFIG_REMAP);
 	LOG_DBG("PCIE_MISC_UBUS_BAR2_CONFIG_REMAP value: 0x%x", tmp);
 	tmp |= PCIE_MISC_UBUS_BAR2_CONFIG_REMAP_ACCESS_ENABLE_MASK;
 	LOG_DBG("Writing PCIE_MISC_UBUS_BAR2_CONFIG_REMAP with value: 0x%x (ACCESS_ENABLE)", tmp);
 	sys_write32(tmp, data->cfg_addr + PCIE_MISC_UBUS_BAR2_CONFIG_REMAP);
-	LOG_DBG("PCIE_MISC_UBUS_BAR2_CONFIG_REMAP after write: 0x%x", sys_read32(data->cfg_addr + PCIE_MISC_UBUS_BAR2_CONFIG_REMAP));
+	LOG_DBG("PCIE_MISC_UBUS_BAR2_CONFIG_REMAP after write: 0x%x",
+		sys_read32(data->cfg_addr + PCIE_MISC_UBUS_BAR2_CONFIG_REMAP));
 
 	/* Set SCB Size */
 	LOG_DBG("Reading PCIE_MISC_MISC_CTRL (offset: 0x%x) for SCB size", PCIE_MISC_MISC_CTRL);
 	tmp = sys_read32(data->cfg_addr + PCIE_MISC_MISC_CTRL);
 	LOG_DBG("PCIE_MISC_MISC_CTRL value: 0x%x", tmp);
 	tmp &= ~PCIE_MISC_MISC_CTRL_SCB0_SIZE_MASK;
-    uint32_t scb_size_val = (ilog2(config->common->ranges[DMA_RANGES_IDX].map_length) - 15)
-                             << PCIE_MISC_MISC_CTRL_SCB0_SIZE_LSB;
-    LOG_DBG("Calculated SCB size value: 0x%x (size: 0x%lx, ilog2 - 15: %d, shift: %d)",
-           scb_size_val, config->common->ranges[DMA_RANGES_IDX].map_length,
-           ilog2(config->common->ranges[DMA_RANGES_IDX].map_length) - 15,
-           PCIE_MISC_MISC_CTRL_SCB0_SIZE_LSB);	
+	uint32_t scb_size_val = (ilog2(config->common->ranges[DMA_RANGES_IDX].map_length) - 15)
+				<< PCIE_MISC_MISC_CTRL_SCB0_SIZE_LSB;
+	LOG_DBG("Calculated SCB size value: 0x%x (size: 0x%lx, ilog2 - 15: %d, shift: %d)",
+		scb_size_val, config->common->ranges[DMA_RANGES_IDX].map_length,
+		ilog2(config->common->ranges[DMA_RANGES_IDX].map_length) - 15,
+		PCIE_MISC_MISC_CTRL_SCB0_SIZE_LSB);
 	tmp |= (ilog2(config->common->ranges[DMA_RANGES_IDX].map_length) - 15)
 	       << PCIE_MISC_MISC_CTRL_SCB0_SIZE_LSB;
 	LOG_DBG("Writing PCIE_MISC_MISC_CTRL with value: 0x%x (SCB0_SIZE)", tmp);
 	sys_write32(tmp, data->cfg_addr + PCIE_MISC_MISC_CTRL);
-	LOG_DBG("PCIE_MISC_MISC_CTRL after write: 0x%x", sys_read32(data->cfg_addr + PCIE_MISC_MISC_CTRL));
+	LOG_DBG("PCIE_MISC_MISC_CTRL after write: 0x%x",
+		sys_read32(data->cfg_addr + PCIE_MISC_MISC_CTRL));
 
 	LOG_DBG("Reading PCIE_MISC_UBUS_CTRL (offset: 0x%x)", PCIE_MISC_UBUS_CTRL);
 	tmp = sys_read32(data->cfg_addr + PCIE_MISC_UBUS_CTRL);
@@ -667,25 +678,29 @@ static int pcie_brcmstb_setup(const struct device *dev)
 	tmp |= PCIE_MISC_UBUS_CTRL_UBUS_PCIE_REPLY_DECERR_DIS_MASK;
 	LOG_DBG("Writing PCIE_MISC_UBUS_CTRL with value: 0x%x (reply error/decerr disable)", tmp);
 	sys_write32(tmp, data->cfg_addr + PCIE_MISC_UBUS_CTRL);
-	LOG_DBG("PCIE_MISC_UBUS_CTRL after write: 0x%x", sys_read32(data->cfg_addr + PCIE_MISC_UBUS_CTRL));
+	LOG_DBG("PCIE_MISC_UBUS_CTRL after write: 0x%x",
+		sys_read32(data->cfg_addr + PCIE_MISC_UBUS_CTRL));
 
-    LOG_DBG("Writing PCIE_MISC_AXI_READ_ERROR_DATA (offset: 0x%x) with value: 0x%x",
-           PCIE_MISC_AXI_READ_ERROR_DATA, 0xffffffff);	
+	LOG_DBG("Writing PCIE_MISC_AXI_READ_ERROR_DATA (offset: 0x%x) with value: 0x%x",
+		PCIE_MISC_AXI_READ_ERROR_DATA, 0xffffffff);
 	sys_write32(0xffffffff, data->cfg_addr + PCIE_MISC_AXI_READ_ERROR_DATA);
-    LOG_DBG("PCIE_MISC_AXI_READ_ERROR_DATA after write: 0x%x", sys_read32(data->cfg_addr + PCIE_MISC_AXI_READ_ERROR_DATA));
+	LOG_DBG("PCIE_MISC_AXI_READ_ERROR_DATA after write: 0x%x",
+		sys_read32(data->cfg_addr + PCIE_MISC_AXI_READ_ERROR_DATA));
 
 	/* Set timeouts */
 	LOG_DBG("Writing PCIE_MISC_UBUS_TIMEOUT (offset: 0x%x) with value: 0x%x",
-           (unsigned int) PCIE_MISC_UBUS_TIMEOUT, (unsigned int) BCM2712_UBUS_TIMEOUT_TICKS);
+		(unsigned int)PCIE_MISC_UBUS_TIMEOUT, (unsigned int)BCM2712_UBUS_TIMEOUT_TICKS);
 	sys_write32(BCM2712_UBUS_TIMEOUT_TICKS, data->cfg_addr + PCIE_MISC_UBUS_TIMEOUT);
-	LOG_DBG("PCIE_MISC_UBUS_TIMEOUT after write: 0x%x", sys_read32(data->cfg_addr + PCIE_MISC_UBUS_TIMEOUT));
+	LOG_DBG("PCIE_MISC_UBUS_TIMEOUT after write: 0x%x",
+		sys_read32(data->cfg_addr + PCIE_MISC_UBUS_TIMEOUT));
 
 	LOG_DBG("Writing PCIE_MISC_RC_CONFIG_RETRY_TIMEOUT (offset: 0x%x) with value: 0x%x",
-           (unsigned int) PCIE_MISC_RC_CONFIG_RETRY_TIMEOUT, (unsigned int) BCM2712_RC_CONFIG_RETRY_TIMEOUT_TICKS);
+		(unsigned int)PCIE_MISC_RC_CONFIG_RETRY_TIMEOUT,
+		(unsigned int)BCM2712_RC_CONFIG_RETRY_TIMEOUT_TICKS);
 	sys_write32(BCM2712_RC_CONFIG_RETRY_TIMEOUT_TICKS,
 		    data->cfg_addr + PCIE_MISC_RC_CONFIG_RETRY_TIMEOUT);
 	LOG_DBG("PCIE_MISC_RC_CONFIG_RETRY_TIMEOUT after write: 0x%x",
-           sys_read32(data->cfg_addr + PCIE_MISC_RC_CONFIG_RETRY_TIMEOUT));			
+		sys_read32(data->cfg_addr + PCIE_MISC_RC_CONFIG_RETRY_TIMEOUT));
 
 	LOG_DBG("Reading PCIE_MISC_RC_BAR1_CONFIG_LO (offset: 0x%x)", PCIE_MISC_RC_BAR1_CONFIG_LO);
 	tmp = sys_read32(data->cfg_addr + PCIE_MISC_RC_BAR1_CONFIG_LO);
@@ -693,7 +708,8 @@ static int pcie_brcmstb_setup(const struct device *dev)
 	tmp &= ~PCIE_MISC_RC_BAR1_CONFIG_LO_SIZE_MASK;
 	LOG_DBG("Writing PCIE_MISC_RC_BAR1_CONFIG_LO with value: 0x%x (size mask cleared)", tmp);
 	sys_write32(tmp, data->cfg_addr + PCIE_MISC_RC_BAR1_CONFIG_LO);
-	LOG_DBG("PCIE_MISC_RC_BAR1_CONFIG_LO after write: 0x%x", sys_read32(data->cfg_addr + PCIE_MISC_RC_BAR1_CONFIG_LO));
+	LOG_DBG("PCIE_MISC_RC_BAR1_CONFIG_LO after write: 0x%x",
+		sys_read32(data->cfg_addr + PCIE_MISC_RC_BAR1_CONFIG_LO));
 
 	LOG_DBG("Reading PCIE_MISC_RC_BAR3_CONFIG_LO (offset: 0x%x)", PCIE_MISC_RC_BAR3_CONFIG_LO);
 	tmp = sys_read32(data->cfg_addr + PCIE_MISC_RC_BAR3_CONFIG_LO);
@@ -701,71 +717,74 @@ static int pcie_brcmstb_setup(const struct device *dev)
 	tmp &= ~PCIE_MISC_RC_BAR3_CONFIG_LO_SIZE_MASK;
 	LOG_DBG("Writing PCIE_MISC_RC_BAR3_CONFIG_LO with value: 0x%x (size mask cleared)", tmp);
 	sys_write32(tmp, data->cfg_addr + PCIE_MISC_RC_BAR3_CONFIG_LO);
-	LOG_DBG("PCIE_MISC_RC_BAR3_CONFIG_LO after write: 0x%x", sys_read32(data->cfg_addr + PCIE_MISC_RC_BAR3_CONFIG_LO));
+	LOG_DBG("PCIE_MISC_RC_BAR3_CONFIG_LO after write: 0x%x",
+		sys_read32(data->cfg_addr + PCIE_MISC_RC_BAR3_CONFIG_LO));
 
-    // 1. Reset Sequence
-    // Assert PERST#
-    LOG_INF("Asserting PERST#");
-    // Assuming pcie->cfg->perst_set is available in your Zephyr environment
-    // If not, you'll need to use the appropriate board-specific GPIO control
-    // to assert the reset.
-    // ret = pcie->cfg->perst_set(pcie, 1); // Assert reset
-    // if (ret) {
-    //     LOG_ERR("Failed to assert PERST#");
-    //     return ret;
-    // }
-    sys_write32(1, data->cfg_addr + 0x108); // Replace 0xXXXX with actual register offset
-    k_sleep(K_MSEC(1)); // 1ms delay - adjust as needed
+	// 1. Reset Sequence
+	// Assert PERST#
+	LOG_INF("Asserting PERST#");
+	// Assuming pcie->cfg->perst_set is available in your Zephyr environment
+	// If not, you'll need to use the appropriate board-specific GPIO control
+	// to assert the reset.
+	// ret = pcie->cfg->perst_set(pcie, 1); // Assert reset
+	// if (ret) {
+	//     LOG_ERR("Failed to assert PERST#");
+	//     return ret;
+	// }
+	sys_write32(1, data->cfg_addr + 0x108); // Replace 0xXXXX with actual register offset
+	k_sleep(K_MSEC(1));                     // 1ms delay - adjust as needed
 
-    // Deassert PERST#
-    LOG_INF("Deasserting PERST#");
-    // ret = pcie->cfg->perst_set(pcie, 0); // Deassert reset
-    // if (ret) {
-    //     LOG_ERR("Failed to deassert PERST#");
-    //     return ret;
-    // }
-    sys_write32(0, data->cfg_addr + 0x108); // Replace 0xXXXX with actual register offset
+	// Deassert PERST#
+	LOG_INF("Deasserting PERST#");
+	// ret = pcie->cfg->perst_set(pcie, 0); // Deassert reset
+	// if (ret) {
+	//     LOG_ERR("Failed to deassert PERST#");
+	//     return ret;
+	// }
+	sys_write32(0, data->cfg_addr + 0x108); // Replace 0xXXXX with actual register offset
 
-    k_sleep(K_MSEC(100)); // 100ms delay after deassertion - adjust as needed
+	k_sleep(K_MSEC(100)); // 100ms delay after deassertion - adjust as needed
 
-     // 2. Wait for Link Up
-    LOG_INF("Waiting for link to come up...");
-    for (int i = 0; i < 20; i++) { // Retry for a maximum of 20 times (5ms * 20 = 100ms)
-        k_sleep(K_MSEC(5));
-        tmp16 = sys_read16(data->cfg_addr + BRCM_PCIE_CAP_REGS + PCI_EXP_LNKSTA);
-        LOG_INF("PCI_EXP_LNKSTA value: 0x%x", tmp16);
-        if (tmp16 & PCI_EXP_LNKSTA_DLLLA) {
-            LOG_INF("Data Link Layer is active.");
-            break;
-        }
-    }
+	// 2. Wait for Link Up
+	LOG_INF("Waiting for link to come up...");
+	for (int i = 0; i < 20; i++) { // Retry for a maximum of 20 times (5ms * 20 = 100ms)
+		k_sleep(K_MSEC(5));
+		tmp16 = sys_read16(data->cfg_addr + BRCM_PCIE_CAP_REGS + PCI_EXP_LNKSTA);
+		LOG_INF("PCI_EXP_LNKSTA value: 0x%x", tmp16);
+		if (tmp16 & PCI_EXP_LNKSTA_DLLLA) {
+			LOG_INF("Data Link Layer is active.");
+			break;
+		}
+	}
 
-    if (!(tmp16 & PCI_EXP_LNKSTA_DLLLA)) {
-        LOG_ERR("Linkup timeout.");
-        return -ENODEV;
-    }	
+	if (!(tmp16 & PCI_EXP_LNKSTA_DLLLA)) {
+		LOG_ERR("Linkup timeout.");
+		return -ENODEV;
+	}
 
 	/* Set gen to 2 */
 	LOG_DBG("Reading PCI_EXP_LNKCTL2 (offset: 0x%x) in BRCM_PCIE_CAP_REGS (offset: 0x%x)",
-           PCI_EXP_LNKCTL2, BRCM_PCIE_CAP_REGS);
+		PCI_EXP_LNKCTL2, BRCM_PCIE_CAP_REGS);
 	tmp16 = sys_read16(data->cfg_addr + BRCM_PCIE_CAP_REGS + PCI_EXP_LNKCTL2);
 	LOG_DBG("Initial PCI_EXP_LNKCTL2 value: 0x%x", tmp16);
 
 	LOG_DBG("Reading PCI_EXP_LNKCAP (offset: 0x%x) in BRCM_PCIE_CAP_REGS (offset: 0x%x)",
-           PCI_EXP_LNKCAP, BRCM_PCIE_CAP_REGS);
+		PCI_EXP_LNKCAP, BRCM_PCIE_CAP_REGS);
 	tmp = sys_read32(data->cfg_addr + BRCM_PCIE_CAP_REGS + PCI_EXP_LNKCAP);
 	LOG_DBG("Initial PCI_EXP_LNKCAP value: 0x%x", tmp);
 	tmp &= ~PCI_EXP_LNKCAP_SLS;
 	tmp |= 0x2;
 	LOG_DBG("Writing PCI_EXP_LNKCAP with value: 0x%x (SLS set to 2)", tmp);
 	sys_write32(tmp, data->cfg_addr + BRCM_PCIE_CAP_REGS + PCI_EXP_LNKCAP);
-	LOG_DBG("PCI_EXP_LNKCAP after write: 0x%x", sys_read32(data->cfg_addr + BRCM_PCIE_CAP_REGS + PCI_EXP_LNKCAP));
+	LOG_DBG("PCI_EXP_LNKCAP after write: 0x%x",
+		sys_read32(data->cfg_addr + BRCM_PCIE_CAP_REGS + PCI_EXP_LNKCAP));
 
 	tmp16 &= ~0xf;
 	tmp16 |= 0x2;
 	LOG_DBG("Writing PCI_EXP_LNKCTL2 with value: 0x%x (Target Link Speed set to 2)", tmp16);
 	sys_write16(tmp16, data->cfg_addr + BRCM_PCIE_CAP_REGS + PCI_EXP_LNKCTL2);
-	LOG_DBG("PCI_EXP_LNKCTL2 after write: 0x%x", sys_read16(data->cfg_addr + BRCM_PCIE_CAP_REGS + PCI_EXP_LNKCTL2));
+	LOG_DBG("PCI_EXP_LNKCTL2 after write: 0x%x",
+		sys_read16(data->cfg_addr + BRCM_PCIE_CAP_REGS + PCI_EXP_LNKCTL2));
 
 	tmp = sys_read32(data->cfg_addr + PCIE_RC_CFG_PRIV1_ID_VAL3);
 	tmp &= ~PCIE_RC_CFG_PRIV1_ID_VAL3_CLASS_CODE_MASK;
@@ -778,11 +797,10 @@ static int pcie_brcmstb_setup(const struct device *dev)
 	       << PCIE_RC_CFG_VENDOR_VENDOR_SPECIFIC_REG1_ENDIAN_MODE_BAR2_LSB;
 	sys_write32(tmp, data->cfg_addr + PCIE_RC_CFG_VENDOR_VENDOR_SPECIFIC_REG1);
 
-
 #define PCI_EXP_LNKSTA_OFFSET 0x12
 
 	LOG_DBG("Reading PCI_EXP_LNKSTA (offset: 0x%x) in BRCM_PCIE_CAP_REGS (offset: 0x%x)",
-	       PCI_EXP_LNKSTA_OFFSET, BRCM_PCIE_CAP_REGS);
+		PCI_EXP_LNKSTA_OFFSET, BRCM_PCIE_CAP_REGS);
 	uint16_t lnksta = sys_read16(data->cfg_addr + BRCM_PCIE_CAP_REGS + PCI_EXP_LNKSTA_OFFSET);
 	LOG_DBG("PCI_EXP_LNKSTA value: 0x%x", lnksta);
 	if (lnksta & PCI_EXP_LNKSTA_DLLLA) {
@@ -793,8 +811,6 @@ static int pcie_brcmstb_setup(const struct device *dev)
 
 	return 0;
 }
-
-
 
 static int pcie_brcmstb_init(const struct device *dev)
 {
@@ -859,7 +875,7 @@ static int pcie_brcmstb_init(const struct device *dev)
 
 	device_map(&test_dma_addr, 0x1b08000000, 0x4000, K_MEM_CACHE_NONE);
 	LOG_INF("H2C 0x%x", sys_read32(test_dma_addr));
-	LOG_INF("C2H 0x%x", sys_read32(test_dma_addr + 0x1000));	
+	LOG_INF("C2H 0x%x", sys_read32(test_dma_addr + 0x1000));
 	return 0;
 }
 
@@ -888,11 +904,12 @@ static int pcie_brcmstb_init(const struct device *dev)
 				{DT_REG_ADDR_BY_IDX(DT_DRV_INST(n), 2),                            \
 				 DT_REG_SIZE_BY_IDX(DT_DRV_INST(n), 2)},                           \
 				{DT_REG_ADDR_BY_IDX(DT_DRV_INST(n), 3),                            \
-				 DT_REG_SIZE_BY_IDX(DT_DRV_INST(n), 3)},                            \
+				 DT_REG_SIZE_BY_IDX(DT_DRV_INST(n), 3)},                           \
 			},                                                                         \
 	};                                                                                         \
                                                                                                    \
 	DEVICE_DT_INST_DEFINE(n, pcie_brcmstb_init, NULL, &pcie_brcmstb_data_##n,                  \
-			      &pcie_brcmstb_cfg_##n, POST_KERNEL, PCIe_BRCMSTB_INIT_PRIO, &pcie_brcmstb_api);
+			      &pcie_brcmstb_cfg_##n, POST_KERNEL, PCIe_BRCMSTB_INIT_PRIO,          \
+			      &pcie_brcmstb_api);
 
 DT_INST_FOREACH_STATUS_OKAY(PCIE_BRCMSTB_INIT)

--- a/drivers/pcie/controller/pcie_brcmstb.c
+++ b/drivers/pcie/controller/pcie_brcmstb.c
@@ -879,7 +879,8 @@ static int pcie_brcmstb_init(const struct device *dev)
 	return 0;
 }
 
-#define PCIe_BRCMSTB_INIT_PRIO 97  /* Just after early kernel subsystems */
+/* Just after early kernel subsystems */
+#define PCIe_BRCMSTB_INIT_PRIO 97
 
 /* TODO: POST_KERNEL is set to use printk, revert this after the development is done */
 #define PCIE_BRCMSTB_INIT(n)                                                                       \

--- a/drivers/pcie/controller/pcie_brcmstb.c
+++ b/drivers/pcie/controller/pcie_brcmstb.c
@@ -814,8 +814,6 @@ static int pcie_brcmstb_setup(const struct device *dev)
 
 static int pcie_brcmstb_init(const struct device *dev)
 {
-	LOG_INF("pcie_brcmstb_init\n");
-
 	const struct pcie_brcmstb_config *config = dev->config;
 	struct pcie_brcmstb_data *data = dev->data;
 	uint32_t tmp;
@@ -823,13 +821,13 @@ static int pcie_brcmstb_init(const struct device *dev)
 
 	if (config->common->ranges_count < DMA_RANGES_IDX) {
 		/* Workaround since macros for `dma-ranges` property is not available */
-		LOG_ERR("pcie_brcmstb_init `dma-ranges` property is not available\n");
+		LOG_ERR("`dma-ranges` property is not available\n");
 		return -EINVAL;
 	}
 
 	ret = pcie_brcmstb_parse_regions(dev);
 	if (ret != 0) {
-		LOG_ERR("pcie_brcmstb_init pcie_brcmstb_parse_regions error\n");
+		LOG_ERR("pcie_brcmstb_parse_regions error\n");
 		return ret;
 	}
 

--- a/drivers/pcie/controller/pcie_brcmstb.c
+++ b/drivers/pcie/controller/pcie_brcmstb.c
@@ -216,8 +216,8 @@ bool pcie_probe(pcie_bdf_t bdf)
 	return found;
 }
 
-#define PCIE_NODE_1 DT_NODELABEL(pcie1) // or use correct label if it's pcie1, etc.
-#define PCIE_NODE_2 DT_NODELABEL(pcie2) // or use correct label if it's pcie1, etc.
+#define PCIE_NODE_1 DT_NODELABEL(pcie1)
+#define PCIE_NODE_2 DT_NODELABEL(pcie2)
 
 void check_pcie_host_status(void)
 {


### PR DESCRIPTION
1. 목적
PCIe device driver 의 상태 초기화 후 ready and active 상태가 되지 않는 문제 해결

2. 중요 수정 범위/파일
- drivers/pcie/controller/pcie_brcmstb.c : 
   DMA_RANGES_IDX 2 -> 3 으로 device tree ranges 에 맞게 수정
   PCIE_BRCMSTB_INIT(n) 에서 device tree regs 수에 맞게 수정
- eth_tsn_nic : DMA_DESC, TSN Top Registers 디버깅 출력 추가
- eth_tsn_priv: dma_tsn_nic_engine_sgdma_regs 값을 캐쉬를 사용하지 않도록 volatile 로 변경

3. 시험 결과
![image](https://github.com/user-attachments/assets/5da59c5a-9ef0-4b9b-920f-f06cf26afb50)

4. 추가 고려 사항 
- DMA 메모리 추가 검토
- DMA Completed Count 가 0 로 아직 packet 이 전송되지 않는 문제   

5. ref: sw-1048