### PR TITLE
Xdma dev sw 1137 fix interrupt enable masking registers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,3 +92,4 @@ ModulesMaintainers.txt
 Nits.txt
 Pylint.txt
 YAMLLint.txt
+samples/tsn_hello/

--- a/drivers/dma/dma_tsn_nic.c
+++ b/drivers/dma/dma_tsn_nic.c
@@ -7,7 +7,7 @@
 #define DT_DRV_COMPAT tsnlab_tsn_nic_dma
 
 #include <zephyr/logging/log.h>
-LOG_MODULE_REGISTER(dma_tsn_nic, LOG_LEVEL_ERR);
+LOG_MODULE_REGISTER(dma_tsn_nic, LOG_LEVEL_DBG);
 
 #include <zephyr/kernel.h>
 #include <zephyr/device.h>
@@ -36,8 +36,8 @@ LOG_MODULE_REGISTER(dma_tsn_nic, LOG_LEVEL_ERR);
 #define DMA_CTRL_IE_DESC_ALIGN_MISMATCH (1UL << 3)
 #define DMA_CTRL_IE_MAGIC_STOPPED       (1UL << 4)
 #define DMA_CTRL_IE_IDLE_STOPPED        (1UL << 6)
-#define DMA_CTRL_IE_READ_ERROR          (1UL << 9)
-#define DMA_CTRL_IE_DESC_ERROR          (1UL << 19)
+#define DMA_CTRL_IE_READ_ERROR          (0x1FUL << 9)
+#define DMA_CTRL_IE_DESC_ERROR          (0x1FUL << 19)
 #define DMA_CTRL_NON_INCR_ADDR          (1UL << 25)
 #define DMA_CTRL_POLL_MODE_WB           (1UL << 26)
 #define DMA_CTRL_STM_MODE_WB            (1UL << 27)
@@ -53,8 +53,11 @@ LOG_MODULE_REGISTER(dma_tsn_nic, LOG_LEVEL_ERR);
 /* Size of BAR1, it needs to be hard-coded as there is no PCIe API for this */
 #define DMA_CONFIG_BAR_SIZE 0x10000
 
+#ifndef XDMA_DMA_ENGINE
+#define XDMA_DMA_ENGINE
 #define DMA_ENGINE_START 16268831
 #define DMA_ENGINE_STOP  16268830
+#endif
 
 struct dma_tsn_nic_config_regs {
 	uint32_t identifier;
@@ -212,15 +215,22 @@ static int engine_init_regs(struct dma_tsn_nic_engine_regs *regs)
 		address_bits = 64;
 	}
 
-	flags = (DMA_CTRL_IE_DESC_ALIGN_MISMATCH | DMA_CTRL_IE_MAGIC_STOPPED |
-		 DMA_CTRL_IE_IDLE_STOPPED | DMA_CTRL_IE_READ_ERROR | DMA_CTRL_IE_DESC_ERROR |
-		 DMA_CTRL_IE_DESC_STOPPED | DMA_CTRL_IE_DESC_COMPLETED);
+    flags = DMA_CTRL_IE_DESC_STOPPED |
+            DMA_CTRL_IE_DESC_COMPLETED |
+            DMA_CTRL_IE_DESC_ALIGN_MISMATCH |
+            DMA_CTRL_IE_MAGIC_STOPPED |
+            DMA_CTRL_IE_IDLE_STOPPED |
+            DMA_CTRL_IE_READ_ERROR |
+            DMA_CTRL_IE_DESC_ERROR;
 
 	sys_write32(flags, (mem_addr_t)&regs->interrupt_enable_mask);
 
-	flags = (DMA_CTRL_RUN_STOP | DMA_CTRL_IE_READ_ERROR | DMA_CTRL_IE_DESC_ERROR |
-		 DMA_CTRL_IE_DESC_ALIGN_MISMATCH | DMA_CTRL_IE_MAGIC_STOPPED |
-		 DMA_CTRL_POLL_MODE_WB);
+    flags = DMA_CTRL_RUN_STOP |
+            DMA_CTRL_IE_READ_ERROR |
+            DMA_CTRL_IE_DESC_ERROR |
+            DMA_CTRL_IE_DESC_ALIGN_MISMATCH |
+            DMA_CTRL_IE_MAGIC_STOPPED |
+            DMA_CTRL_POLL_MODE_WB;
 
 	sys_write32(flags, (mem_addr_t)&regs->control);
 
@@ -257,6 +267,8 @@ static int dma_tsn_nic_init(const struct device *dev)
 	struct dma_tsn_nic_data *data = dev->data;
 	struct dma_tsn_nic_engine_regs *regs;
 	int engine_id, channel_id;
+
+	LOG_INF("init: %s\n", dev->name);
 
 	if (map_bar(dev, 0, 0x1000) != 0) {
 		return -EINVAL;

--- a/drivers/dma/dma_tsn_nic.c
+++ b/drivers/dma/dma_tsn_nic.c
@@ -215,22 +215,14 @@ static int engine_init_regs(struct dma_tsn_nic_engine_regs *regs)
 		address_bits = 64;
 	}
 
-    flags = DMA_CTRL_IE_DESC_STOPPED |
-            DMA_CTRL_IE_DESC_COMPLETED |
-            DMA_CTRL_IE_DESC_ALIGN_MISMATCH |
-            DMA_CTRL_IE_MAGIC_STOPPED |
-            DMA_CTRL_IE_IDLE_STOPPED |
-            DMA_CTRL_IE_READ_ERROR |
-            DMA_CTRL_IE_DESC_ERROR;
+	flags = DMA_CTRL_IE_DESC_STOPPED | DMA_CTRL_IE_DESC_COMPLETED |
+		DMA_CTRL_IE_DESC_ALIGN_MISMATCH | DMA_CTRL_IE_MAGIC_STOPPED |
+		DMA_CTRL_IE_IDLE_STOPPED | DMA_CTRL_IE_READ_ERROR | DMA_CTRL_IE_DESC_ERROR;
 
 	sys_write32(flags, (mem_addr_t)&regs->interrupt_enable_mask);
 
-    flags = DMA_CTRL_RUN_STOP |
-            DMA_CTRL_IE_READ_ERROR |
-            DMA_CTRL_IE_DESC_ERROR |
-            DMA_CTRL_IE_DESC_ALIGN_MISMATCH |
-            DMA_CTRL_IE_MAGIC_STOPPED |
-            DMA_CTRL_POLL_MODE_WB;
+	flags = DMA_CTRL_RUN_STOP | DMA_CTRL_IE_READ_ERROR | DMA_CTRL_IE_DESC_ERROR |
+		DMA_CTRL_IE_DESC_ALIGN_MISMATCH | DMA_CTRL_IE_MAGIC_STOPPED | DMA_CTRL_POLL_MODE_WB;
 
 	sys_write32(flags, (mem_addr_t)&regs->control);
 

--- a/drivers/ethernet/eth_tsn_nic.c
+++ b/drivers/ethernet/eth_tsn_nic.c
@@ -17,8 +17,8 @@ LOG_MODULE_REGISTER(eth_tsn_nic, LOG_LEVEL_DBG);
 #include <zephyr/sys/device_mmio.h>
 #include <zephyr/sys/byteorder.h>
 
-#include <zephyr/kernel/mm.h>  // For arch_mem_get_phys
-#include <zephyr/devicetree.h> // Required for DT_NODELABEL, DT_REG_SIZE, DT_NODE_EXISTS
+#include <zephyr/kernel/mm.h>
+#include <zephyr/devicetree.h>
 
 #include <zephyr/net/ethernet.h>
 #include <zephyr/drivers/dma.h>
@@ -380,9 +380,9 @@ static int eth_tsn_nic_send(const struct device *dev, struct net_pkt *pkt)
 	k_work_submit(&data->rx_work); /* TODO: use polling for now */
 #endif
 
-	//	tsn_print_top_registers(dev);
+	tsn_print_top_registers(dev);
 
-	//	eth_tsn_check_status();
+	eth_tsn_check_status();
 
 	pthread_spin_lock(&data->tx_lock);
 

--- a/drivers/ethernet/eth_tsn_nic.c
+++ b/drivers/ethernet/eth_tsn_nic.c
@@ -17,7 +17,7 @@ LOG_MODULE_REGISTER(eth_tsn_nic, LOG_LEVEL_DBG);
 #include <zephyr/sys/device_mmio.h>
 #include <zephyr/sys/byteorder.h>
 
-#include <zephyr/kernel/mm.h>// For arch_mem_get_phys
+#include <zephyr/kernel/mm.h>  // For arch_mem_get_phys
 #include <zephyr/devicetree.h> // Required for DT_NODELABEL, DT_REG_SIZE, DT_NODE_EXISTS
 
 #include <zephyr/net/ethernet.h>
@@ -380,9 +380,9 @@ static int eth_tsn_nic_send(const struct device *dev, struct net_pkt *pkt)
 	k_work_submit(&data->rx_work); /* TODO: use polling for now */
 #endif
 
-//	tsn_print_top_registers(dev);
+	//	tsn_print_top_registers(dev);
 
-//	eth_tsn_check_status();
+	//	eth_tsn_check_status();
 
 	pthread_spin_lock(&data->tx_lock);
 
@@ -440,8 +440,7 @@ static int eth_tsn_nic_send(const struct device *dev, struct net_pkt *pkt)
 	dump_dma_h2c_all_regs(data->regs[DMA_H2C]);
 
 	/* offset = completed_desc_count */
-	uint32_t completed =
-		sys_read32((uintptr_t)data->regs[DMA_H2C] + 0x48);
+	uint32_t completed = sys_read32((uintptr_t)data->regs[DMA_H2C] + 0x48);
 
 	LOG_DBG("Completed Desc Count: %d\n", completed);
 
@@ -520,21 +519,14 @@ static int engine_init_regs(struct dma_tsn_nic_engine_regs *regs)
 		address_bits = 64;
 	}
 
-    flags = DMA_CTRL_IE_DESC_STOPPED |
-            DMA_CTRL_IE_DESC_COMPLETED |
-            DMA_CTRL_IE_DESC_ALIGN_MISMATCH |
-            DMA_CTRL_IE_MAGIC_STOPPED |
-            DMA_CTRL_IE_READ_ERROR |
-            DMA_CTRL_IE_DESC_ERROR;
+	flags = DMA_CTRL_IE_DESC_STOPPED | DMA_CTRL_IE_DESC_COMPLETED |
+		DMA_CTRL_IE_DESC_ALIGN_MISMATCH | DMA_CTRL_IE_MAGIC_STOPPED |
+		DMA_CTRL_IE_READ_ERROR | DMA_CTRL_IE_DESC_ERROR;
 
 	sys_write32(flags, (mem_addr_t)&regs->interrupt_enable_mask);
 
-
-    flags = DMA_CTRL_RUN_STOP |
-            DMA_CTRL_IE_READ_ERROR |
-            DMA_CTRL_IE_DESC_ERROR |
-            DMA_CTRL_IE_DESC_ALIGN_MISMATCH |
-            DMA_CTRL_IE_MAGIC_STOPPED;
+	flags = DMA_CTRL_RUN_STOP | DMA_CTRL_IE_READ_ERROR | DMA_CTRL_IE_DESC_ERROR |
+		DMA_CTRL_IE_DESC_ALIGN_MISMATCH | DMA_CTRL_IE_MAGIC_STOPPED;
 
 	sys_write32(flags, (mem_addr_t)&regs->control);
 
@@ -652,4 +644,3 @@ static int eth_tsn_nic_init(const struct device *dev)
 				      &eth_tsn_nic_cfg_##n, 99, &eth_tsn_nic_api, NET_ETH_MTU);
 
 DT_INST_FOREACH_STATUS_OKAY(ETH_TSN_NIC_INIT)
-

--- a/drivers/ethernet/eth_tsn_nic_priv.h
+++ b/drivers/ethernet/eth_tsn_nic_priv.h
@@ -150,18 +150,18 @@ struct dma_tsn_nic_result {
 	uint32_t _reserved1[6]; /* padding */
 };
 
-#define LOG_DESC(desc_ptr)	\
-	do {	\
-		const struct dma_tsn_nic_desc *desc = (desc_ptr);	\
-		LOG_DBG("DMA DESC @ %p:", desc);	\
-		LOG_DBG("  control     : 0x%08x", desc->control);	\
-		LOG_DBG("  bytes       : 0x%08x", desc->bytes);	\
-		LOG_DBG("  src_addr_lo : 0x%08x", desc->src_addr_lo);	\
-		LOG_DBG("  src_addr_hi : 0x%08x", desc->src_addr_hi);	\
-		LOG_DBG("  dst_addr_lo : 0x%08x", desc->dst_addr_lo);	\
-		LOG_DBG("  dst_addr_hi : 0x%08x", desc->dst_addr_hi);	\
-		LOG_DBG("  next_lo     : 0x%08x", desc->next_lo);	\
-		LOG_DBG("  next_hi     : 0x%08x", desc->next_hi);	\
+#define LOG_DESC(desc_ptr)                                                                         \
+	do {                                                                                       \
+		const struct dma_tsn_nic_desc *desc = (desc_ptr);                                  \
+		LOG_DBG("DMA DESC @ %p:", desc);                                                   \
+		LOG_DBG("  control     : 0x%08x", desc->control);                                  \
+		LOG_DBG("  bytes       : 0x%08x", desc->bytes);                                    \
+		LOG_DBG("  src_addr_lo : 0x%08x", desc->src_addr_lo);                              \
+		LOG_DBG("  src_addr_hi : 0x%08x", desc->src_addr_hi);                              \
+		LOG_DBG("  dst_addr_lo : 0x%08x", desc->dst_addr_lo);                              \
+		LOG_DBG("  dst_addr_hi : 0x%08x", desc->dst_addr_hi);                              \
+		LOG_DBG("  next_lo     : 0x%08x", desc->next_lo);                                  \
+		LOG_DBG("  next_hi     : 0x%08x", desc->next_hi);                                  \
 	} while (0)
 
 /**

--- a/drivers/ethernet/eth_tsn_nic_priv.h
+++ b/drivers/ethernet/eth_tsn_nic_priv.h
@@ -32,21 +32,22 @@
 #define DMA_ENGINE_ID_MASK  0xffff0000
 #define DMA_ENGINE_ID_LSB   16
 
-#define DMA_ALIGN_BYTES_MASK       0x00ff0000
-#define DMA_ALIGN_BYTES_LSB        16
+#define DMA_ALIGN_BYTES_MASK       0x000000ff
+#define DMA_ALIGN_BYTES_LSB        0
 #define DMA_GRANULARITY_BYTES_MASK 0x0000ff00
 #define DMA_GRANULARITY_BYTES_LSB  8
-#define DMA_ADDRESS_BITS_MASK      0x000000ff
-#define DMA_ADDRESS_BITS_LSB       0
+#define DMA_ADDRESS_BITS_MASK      0xff00000
+#define DMA_ADDRESS_BITS_LSB       24
 
 #define DMA_CTRL_RUN_STOP               (1UL << 0)
 #define DMA_CTRL_IE_DESC_STOPPED        (1UL << 1)
 #define DMA_CTRL_IE_DESC_COMPLETED      (1UL << 2)
 #define DMA_CTRL_IE_DESC_ALIGN_MISMATCH (1UL << 3)
 #define DMA_CTRL_IE_MAGIC_STOPPED       (1UL << 4)
+#define DMA_CTRL_IE_INVALID_LENGTH      (1UL << 5)
 #define DMA_CTRL_IE_IDLE_STOPPED        (1UL << 6)
-#define DMA_CTRL_IE_READ_ERROR          (1UL << 9)
-#define DMA_CTRL_IE_DESC_ERROR          (1UL << 19)
+#define DMA_CTRL_IE_READ_ERROR          (0x1FUL << 9)
+#define DMA_CTRL_IE_DESC_ERROR          (0x1FUL << 19)
 #define DMA_CTRL_NON_INCR_ADDR          (1UL << 25)
 #define DMA_CTRL_POLL_MODE_WB           (1UL << 26)
 #define DMA_CTRL_STM_MODE_WB            (1UL << 27)


### PR DESCRIPTION
1. 목적
interrupt enable masking registers 값 수정

2. 주요 변경 사항
- drivers/ethernet/eth_tsn_nic_priv.h
DMA_CTRL_IE_READ_ERROR , DMA_CTRL_IE_DESC_ERROR  값 수정
- drivers/ethernet/eth_tsn_nic.c
engine_init_regs 에서 flag 설정 값 변경

3. 시험 결과
![image](https://github.com/user-attachments/assets/32b6c9f6-bfd2-4088-b48a-1fafacfcff91)

4. 추가 고려 사항
- completed desc count 가 0
- status, status_rc 값이 MAGIC STOP 오류 