### PR TITLE
Add LAN865x pseudo-driver

### DIFF
--- a/boards/tcc/topst_vcp45/topst_vcp45.dts
+++ b/boards/tcc/topst_vcp45/topst_vcp45.dts
@@ -17,6 +17,7 @@
 
 	aliases {
 		led0 = &led_act;
+		spi0 = &spi0;
 	};
 
 	chosen {

--- a/boards/tcc/topst_vcp45/topst_vcp45.dts
+++ b/boards/tcc/topst_vcp45/topst_vcp45.dts
@@ -67,5 +67,5 @@
 
 &spi0 {
 	status = "okay";
-	clock-frequency = <12000000>;
+	clock-frequency = <50000000>;
 };

--- a/boards/tcc/topst_vcp45/topst_vcp45.dts
+++ b/boards/tcc/topst_vcp45/topst_vcp45.dts
@@ -30,7 +30,7 @@
 		compatible = "gpio-leds";
 
 		led_act: led-act {
-			gpios = <&gio_aon 6 GPIO_ACTIVE_HIGH>;
+			gpios = <&gpiob 6 GPIO_ACTIVE_HIGH>;
 			label = "ACT";
 		};
 	};
@@ -41,7 +41,7 @@
 	status = "okay";
 };
 
-&gio_aon {
+&gpiob {
 	status = "okay";
 };
 

--- a/drivers/gpio/gpio_tccvcp.c
+++ b/drivers/gpio/gpio_tccvcp.c
@@ -362,11 +362,10 @@ static const struct gpio_driver_api gpio_tccvcp_api = {
 
 static int gpio_tccvcp_init(const struct device *port)
 {
-	const struct gpio_tccvcp_config *config = port->config;
 	struct gpio_tccvcp_data *data = port->data;
 
 	DEVICE_MMIO_NAMED_MAP(port, reg_base, K_MEM_CACHE_NONE);
-	data->base = DEVICE_MMIO_NAMED_GET(port, reg_base) + config->offset;
+	data->base = DEVICE_MMIO_NAMED_GET(port, reg_base);
 
 	return 0;
 }
@@ -376,8 +375,7 @@ static int gpio_tccvcp_init(const struct device *port)
                                                                                                    \
 	static const struct gpio_tccvcp_config gpio_tccvcp_cfg_##n = {                             \
 		.common = {.port_pin_mask = GPIO_PORT_PIN_MASK_FROM_DT_INST(0)},                   \
-		DEVICE_MMIO_NAMED_ROM_INIT(reg_base, DT_INST_PARENT(n)),                           \
-		.offset = DT_INST_REG_ADDR(n),                                                     \
+		DEVICE_MMIO_NAMED_ROM_INIT(reg_base, DT_DRV_INST(n)),                           \
 	};                                                                                         \
                                                                                                    \
 	DEVICE_DT_INST_DEFINE(n, gpio_tccvcp_init, NULL, &gpio_tccvcp_data_##n,                    \

--- a/drivers/spi/spi_tccvcp.c
+++ b/drivers/spi/spi_tccvcp.c
@@ -221,7 +221,8 @@ static int spi_tccvcp_configure(const struct device *port, const struct spi_conf
 	return 0;
 }
 
-static int spi_tccvcp_dma_start(const struct device *port, uint32_t length, const uint8_t *tx_buf, uint8_t *rx_buf)
+static int spi_tccvcp_dma_start(const struct device *port, uint32_t length, const uint8_t *tx_buf,
+				uint8_t *rx_buf)
 {
 	struct spi_tccvcp_data *data = port->data;
 
@@ -231,7 +232,8 @@ static int spi_tccvcp_dma_start(const struct device *port, uint32_t length, cons
 	sys_write32((uint32_t)tx_buf, SPI_TXBASE(data->reg_base));
 	sys_write32((uint32_t)rx_buf, SPI_RXBASE(data->reg_base));
 
-	sys_write32(SPI_DMA_CTR_DTE | SPI_DMA_CTR_DRE | SPI_DMA_CTR_EN, SPI_DMA_CTRL(data->reg_base));
+	sys_write32(SPI_DMA_CTR_DTE | SPI_DMA_CTR_DRE | SPI_DMA_CTR_EN,
+		    SPI_DMA_CTRL(data->reg_base));
 
 	return 0;
 }
@@ -388,9 +390,10 @@ static int spi_tccvcp_init(const struct device *port)
 	sys_write32(spi_mode, SPI_MODE(data->reg_base));
 
 	/* Configure DMA settings */
-	sys_write32(0, SPI_DMA_CTRL(data->reg_base));  /* Clear everything */
-	sys_write32(SPI_INTEN_DW | SPI_INTEN_DR, SPI_INTEN(data->reg_base));  /* TODO: This might be unnecessary */
-	sys_write32(SPI_DMA_CTR_PCLR, SPI_DMA_CTRL(data->reg_base));  /* Clear state bits */
+	sys_write32(0, SPI_DMA_CTRL(data->reg_base)); /* Clear everything */
+	sys_write32(SPI_INTEN_DW | SPI_INTEN_DR,
+		    SPI_INTEN(data->reg_base)); /* TODO: This might be unnecessary */
+	sys_write32(SPI_DMA_CTR_PCLR, SPI_DMA_CTRL(data->reg_base)); /* Clear state bits */
 
 	uint32_t dma_icr = sys_read32(SPI_DMA_ICR(data->reg_base));
 	dma_icr |= SPI_DMA_ICR_IED;

--- a/drivers/spi/spi_tccvcp.c
+++ b/drivers/spi/spi_tccvcp.c
@@ -254,14 +254,6 @@ static int spi_tccvcp_xfer(const struct device *port)
 		stat = sys_read32(SPI_STAT(data->reg_base));
 		wth = SPI_STAT_WTH(stat);
 		rth = SPI_STAT_RTH(stat);
-
-		/* TODO: Communicating with RPi needs this */
-		/* TODO: This needs to be tested with other devices */
-		volatile int iii = 100000;
-
-		while (iii--) {
-			arch_nop();
-		}
 	}
 
 	return 0;

--- a/drivers/spi/spi_tccvcp.c
+++ b/drivers/spi/spi_tccvcp.c
@@ -153,7 +153,7 @@ static int spi_tccvcp_configure(const struct device *port, const struct spi_conf
 		spi_mode &= ~SPI_MODE_LB_MASK;
 	}
 
-	if (spi_cfg->operation & SPI_TRANSFER_MSB) {
+	if (spi_cfg->operation & SPI_TRANSFER_LSB) {
 		spi_mode |= SPI_MODE_SD_MASK;
 	} else {
 		spi_mode &= ~SPI_MODE_SD_MASK;

--- a/drivers/spi/spi_tccvcp.c
+++ b/drivers/spi/spi_tccvcp.c
@@ -104,7 +104,7 @@ LOG_MODULE_REGISTER(spi_tccvcp, CONFIG_SPI_LOG_LEVEL);
 #define PERI_CLK_GPSB0_CLK_SRC_MASK (0x1F << 24)
 #define PERI_CLK_GPSB0_CLK_SRC_PLL0 (0x0 << 24)
 #define PERI_CLK_GPSB0_CLK_DIV_MASK (0xFFF << 0)
-#define PLL0_FREQ                   120000000UL /* 1200MHz */
+#define PLL0_FREQ                   1200000000UL /* 1200MHz */
 
 struct spi_tccvcp_config {
 	DEVICE_MMIO_NAMED_ROM(reg_base);

--- a/dts/arm/tcc/tcc70xx.dtsi
+++ b/dts/arm/tcc/tcc70xx.dtsi
@@ -198,44 +198,46 @@
 		};
 
 		gpioa@a0f22000 {
-			compatible = "simple-bus";
+			compatible = "tcc,tccvcp-gpio";
 			reg = <0xa0f22000 0x40>;
 
 			#address-cells = <1>;
 			#size-cells = <0>;
+
+			status = "disabled";
 		};
 
-		gpiob@a0f22040 {
-			compatible = "simple-bus";
+		gpiob: gpio@a0f22040 {
+			compatible = "tcc,tccvcp-gpio";
 			reg = <0xa0f22040 0x40>;
 
 			#address-cells = <1>;
 			#size-cells = <0>;
 
-			gio_aon: gpio@0 {
-				compatible = "tcc,tccvcp-gpio";
-				reg = <0>;
-				gpio-controller;
-				#gpio-cells = <2>;
-				ngpios = <29>;
-				status = "disabled";
-			};
+			gpio-controller;
+			#gpio-cells = <2>;
+			ngpios = <29>;
+			status = "disabled";
 		};
 
 		gpioc@a0f22080 {
-			compatible = "simple-bus";
+			compatible = "tcc,tccvcp-gpio";
 			reg = <0xa0f22080 0x40>;
 
 			#address-cells = <1>;
 			#size-cells = <0>;
+
+			status = "disabled";
 		};
 
 		gpiok@a0f220c0 {
-			compatible = "simple-bus";
+			compatible = "tcc,tccvcp-gpio";
 			reg = <0xa0f220c0 0x40>;
 
 			#address-cells = <1>;
 			#size-cells = <0>;
+
+			status = "disabled";
 		};
 
 		spi0: spi@a0100000 {
@@ -246,10 +248,10 @@
 			#address-cells = <1>;
 			#size-cells = <0>;
 
-			clk-gpios = <&gio_aon 4 GPIO_ACTIVE_HIGH>;
-			mosi-gpios = <&gio_aon 6 GPIO_ACTIVE_HIGH>;
-			miso-gpios = <&gio_aon 7 GPIO_ACTIVE_HIGH>;
-			cs-gpios = <&gio_aon 5 GPIO_ACTIVE_LOW>;
+			clk-gpios = <&gpiob 4 GPIO_ACTIVE_HIGH>;
+			mosi-gpios = <&gpiob 6 GPIO_ACTIVE_HIGH>;
+			miso-gpios = <&gpiob 7 GPIO_ACTIVE_HIGH>;
+			cs-gpios = <&gpiob 5 GPIO_ACTIVE_LOW>;
 		};
 	};
 };

--- a/samples/t1s/CMakeLists.txt
+++ b/samples/t1s/CMakeLists.txt
@@ -1,0 +1,9 @@
+# SPDX-License-Identifier: Apache-2.0
+
+cmake_minimum_required(VERSION 3.20.0)
+find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
+project(t1s)
+
+target_sources(app PRIVATE src/main.c src/lan8651.c src/arp.c)
+target_include_directories(app PRIVATE src)
+

--- a/samples/t1s/CMakeLists.txt
+++ b/samples/t1s/CMakeLists.txt
@@ -4,6 +4,5 @@ cmake_minimum_required(VERSION 3.20.0)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(t1s)
 
-target_sources(app PRIVATE src/main.c src/lan8651.c src/arp.c)
-target_include_directories(app PRIVATE src)
+target_sources(app PRIVATE src/main.c src/lan8651.c src/arp.c src/spi.c)
 

--- a/samples/t1s/CMakeLists.txt
+++ b/samples/t1s/CMakeLists.txt
@@ -4,5 +4,5 @@ cmake_minimum_required(VERSION 3.20.0)
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(t1s)
 
-target_sources(app PRIVATE src/main.c src/lan8651.c src/arp.c src/spi.c)
+target_sources(app PRIVATE src/main.c src/lan8651.c src/arp.c src/spi.c src/perf.c)
 

--- a/samples/t1s/prj.conf
+++ b/samples/t1s/prj.conf
@@ -1,0 +1,1 @@
+CONFIG_SPI=y

--- a/samples/t1s/src/arp.c
+++ b/samples/t1s/src/arp.c
@@ -42,7 +42,7 @@ int receive_arp_reply(const struct spi_dt_spec* spi) {
     uint8_t packet[MAX_PACKET_SIZE] = {0,};
     uint16_t length = 0;
 
-    while (length > 0) {
+    while (length == 0) {
         if (receive_packet(spi, packet, &length) < 0) {
             printk("Failed to receive ARP reply\n");
             return -1;

--- a/samples/t1s/src/arp.c
+++ b/samples/t1s/src/arp.c
@@ -1,0 +1,104 @@
+#include <stdint.h>
+
+#include <zephyr/drivers/spi.h>
+#include <zephyr/sys/byteorder.h>
+#include <zephyr/sys/printk.h>
+
+#include "eth.h"
+#include "lan8651.h"
+
+static uint16_t make_arp_request_packet(uint8_t* packet, const uint8_t my_mac_addr[ETH_ALEN], const uint8_t my_ip_addr[IP_LEN], const uint8_t target_ip_addr[IP_LEN]) {
+
+    struct ethhdr* eth = (struct ethhdr*)packet;
+    struct arphdr_ipv4* arp = (struct arphdr_ipv4*)(eth + 1);
+
+    // Fill Ethernet header
+    memset(eth->h_dest, 0xFF, ETH_ALEN); // Broadcast
+    memcpy(eth->h_source, my_mac_addr, ETH_ALEN);
+    eth->h_proto = sys_cpu_to_be16(ETH_P_ARP);
+
+    // Fill ARP header
+    arp->arp.ar_hrd = sys_cpu_to_be16(1);
+    arp->arp.ar_pro = sys_cpu_to_be16(ETH_P_IP);
+    arp->arp.ar_hln = ETH_ALEN;
+    arp->arp.ar_pln = IP_LEN;
+    arp->arp.ar_op = sys_cpu_to_be16(ARPOP_REQUEST);
+    memcpy(arp->sender_mac, my_mac_addr, ETH_ALEN);
+    memcpy(arp->sender_ip, my_ip_addr, IP_LEN);
+    memset(arp->target_mac, 0x00, ETH_ALEN); // Unknown
+    memcpy(arp->target_ip, target_ip_addr, IP_LEN);
+
+    return PACKET_SIZE_ARP;
+}
+
+int send_arp_request(const struct spi_dt_spec* spi, const uint8_t my_mac_addr[ETH_ALEN], const uint8_t my_ip_addr[IP_LEN], const uint8_t target_ip_addr[IP_LEN]) {
+    uint8_t packet[PACKET_SIZE_ARP];
+    uint16_t length = make_arp_request_packet(packet, my_mac_addr, my_ip_addr, target_ip_addr);
+
+    return send_packet(spi, packet, length);
+}
+
+int receive_arp_reply(const struct spi_dt_spec* spi) {
+    uint8_t packet[MAX_PACKET_SIZE] = {0,};
+    uint16_t length = 0;
+
+    while (length > 0) {
+        if (receive_packet(spi, packet, &length) < 0) {
+            printk("Failed to receive ARP reply\n");
+            return -1;
+        }
+    }
+
+    struct ethhdr* eth = (struct ethhdr*)packet;
+    struct arphdr_ipv4* arp = (struct arphdr_ipv4*)(eth + 1);
+
+    if (eth->h_proto != sys_cpu_to_be16(ETH_P_ARP)) {
+        printk("Invalid ARP packet\n");
+    }
+
+    if (arp->arp.ar_op != sys_cpu_to_be16(ARPOP_REPLY)) {
+        printk("Invalid ARP reply\n");
+        return -1;
+    }    
+
+    printk("ARP Request: \n");
+    printk("=== Ethernet Header ===\n");
+    printk("Destination MAC: %02x:%02x:%02x:%02x:%02x:%02x\n", 
+           packet[0], packet[1], packet[2], 
+           packet[3], packet[4], packet[5]);
+    printk("Source MAC: %02x:%02x:%02x:%02x:%02x:%02x\n", 
+           packet[6], packet[7], packet[8], 
+           packet[9], packet[10], packet[11]);
+    
+    uint16_t tx_ethertype = (packet[12] << 8) | packet[13];
+    printk("EtherType: 0x%04x (%s)\n", tx_ethertype, tx_ethertype == 0x0806 ? "ARP" : "Unknown");
+    
+    printk("\n=== ARP Header ===\n");
+    uint16_t tx_hw_type = (packet[14] << 8) | packet[15];
+    printk("Hardware Type: 0x%04x (%s)\n", tx_hw_type, tx_hw_type == 0x0001 ? "Ethernet" : "Unknown");
+    
+    uint16_t tx_proto_type = (packet[16] << 8) | packet[17];
+    printk("Protocol Type: 0x%04x (%s)\n", tx_proto_type, tx_proto_type == 0x0800 ? "IPv4" : "Unknown");
+    
+    uint8_t tx_hw_size = packet[18];
+    uint8_t tx_proto_size = packet[19];
+    printk("Hardware Size: %d bytes\n", tx_hw_size);
+    printk("Protocol Size: %d bytes\n", tx_proto_size);
+    
+    uint16_t tx_operation = (packet[20] << 8) | packet[21];
+    printk("Operation: 0x%04x (%s)\n", tx_operation, tx_operation == 0x0001 ? "Request" : tx_operation == 0x0002 ? "Reply" : "Unknown");
+    
+    printk("\nSender MAC: %02x:%02x:%02x:%02x:%02x:%02x\n", 
+           packet[22], packet[23], packet[24], 
+           packet[25], packet[26], packet[27]);
+    printk("Sender IP: %d.%d.%d.%d\n", 
+           packet[28], packet[29], packet[30], packet[31]);
+    
+    printk("Target MAC: %02x:%02x:%02x:%02x:%02x:%02x\n", 
+           packet[32], packet[33], packet[34], 
+           packet[35], packet[36], packet[37]);
+    printk("Target IP: %d.%d.%d.%d\n", 
+           packet[38], packet[39], packet[40], packet[41]);
+
+    return 0;
+}

--- a/samples/t1s/src/arp.c
+++ b/samples/t1s/src/arp.c
@@ -7,98 +7,106 @@
 #include "eth.h"
 #include "lan8651.h"
 
-static uint16_t make_arp_request_packet(uint8_t* packet, const uint8_t my_mac_addr[ETH_ALEN], const uint8_t my_ip_addr[IP_LEN], const uint8_t target_ip_addr[IP_LEN]) {
+static uint16_t make_arp_request_packet(uint8_t *packet, const uint8_t my_mac_addr[ETH_ALEN],
+					const uint8_t my_ip_addr[IP_LEN],
+					const uint8_t target_ip_addr[IP_LEN])
+{
 
-    struct ethhdr* eth = (struct ethhdr*)packet;
-    struct arphdr_ipv4* arp = (struct arphdr_ipv4*)(eth + 1);
+	struct ethhdr *eth = (struct ethhdr *)packet;
+	struct arphdr_ipv4 *arp = (struct arphdr_ipv4 *)(eth + 1);
 
-    // Fill Ethernet header
-    memset(eth->h_dest, 0xFF, ETH_ALEN); // Broadcast
-    memcpy(eth->h_source, my_mac_addr, ETH_ALEN);
-    eth->h_proto = sys_cpu_to_be16(ETH_P_ARP);
+	// Fill Ethernet header
+	memset(eth->h_dest, 0xFF, ETH_ALEN); // Broadcast
+	memcpy(eth->h_source, my_mac_addr, ETH_ALEN);
+	eth->h_proto = sys_cpu_to_be16(ETH_P_ARP);
 
-    // Fill ARP header
-    arp->arp.ar_hrd = sys_cpu_to_be16(1);
-    arp->arp.ar_pro = sys_cpu_to_be16(ETH_P_IP);
-    arp->arp.ar_hln = ETH_ALEN;
-    arp->arp.ar_pln = IP_LEN;
-    arp->arp.ar_op = sys_cpu_to_be16(ARPOP_REQUEST);
-    memcpy(arp->sender_mac, my_mac_addr, ETH_ALEN);
-    memcpy(arp->sender_ip, my_ip_addr, IP_LEN);
-    memset(arp->target_mac, 0x00, ETH_ALEN); // Unknown
-    memcpy(arp->target_ip, target_ip_addr, IP_LEN);
+	// Fill ARP header
+	arp->arp.ar_hrd = sys_cpu_to_be16(1);
+	arp->arp.ar_pro = sys_cpu_to_be16(ETH_P_IP);
+	arp->arp.ar_hln = ETH_ALEN;
+	arp->arp.ar_pln = IP_LEN;
+	arp->arp.ar_op = sys_cpu_to_be16(ARPOP_REQUEST);
+	memcpy(arp->sender_mac, my_mac_addr, ETH_ALEN);
+	memcpy(arp->sender_ip, my_ip_addr, IP_LEN);
+	memset(arp->target_mac, 0x00, ETH_ALEN); // Unknown
+	memcpy(arp->target_ip, target_ip_addr, IP_LEN);
 
-    return PACKET_SIZE_ARP;
+	return PACKET_SIZE_ARP;
 }
 
-int send_arp_request(const struct spi_dt_spec* spi, const uint8_t my_mac_addr[ETH_ALEN], const uint8_t my_ip_addr[IP_LEN], const uint8_t target_ip_addr[IP_LEN]) {
-    uint8_t packet[PACKET_SIZE_ARP];
-    uint16_t length = make_arp_request_packet(packet, my_mac_addr, my_ip_addr, target_ip_addr);
+int send_arp_request(const struct spi_dt_spec *spi, const uint8_t my_mac_addr[ETH_ALEN],
+		     const uint8_t my_ip_addr[IP_LEN], const uint8_t target_ip_addr[IP_LEN])
+{
+	uint8_t packet[PACKET_SIZE_ARP];
+	uint16_t length = make_arp_request_packet(packet, my_mac_addr, my_ip_addr, target_ip_addr);
 
-    return send_packet(spi, packet, length);
+	return send_packet(spi, packet, length);
 }
 
-int receive_arp_reply(const struct spi_dt_spec* spi) {
-    uint8_t packet[MAX_PACKET_SIZE] = {0,};
-    uint16_t length = 0;
+int receive_arp_reply(const struct spi_dt_spec *spi)
+{
+	uint8_t packet[MAX_PACKET_SIZE] = {
+		0,
+	};
+	uint16_t length = 0;
 
-    while (length == 0) {
-        if (receive_packet(spi, packet, &length) < 0) {
-            printk("Failed to receive ARP reply\n");
-            return -1;
-        }
-    }
+	while (length == 0) {
+		if (receive_packet(spi, packet, &length) < 0) {
+			printk("Failed to receive ARP reply\n");
+			return -1;
+		}
+	}
 
-    struct ethhdr* eth = (struct ethhdr*)packet;
-    struct arphdr_ipv4* arp = (struct arphdr_ipv4*)(eth + 1);
+	struct ethhdr *eth = (struct ethhdr *)packet;
+	struct arphdr_ipv4 *arp = (struct arphdr_ipv4 *)(eth + 1);
 
-    if (eth->h_proto != sys_cpu_to_be16(ETH_P_ARP)) {
-        printk("Invalid ARP packet\n");
-    }
+	if (eth->h_proto != sys_cpu_to_be16(ETH_P_ARP)) {
+		printk("Invalid ARP packet\n");
+	}
 
-    if (arp->arp.ar_op != sys_cpu_to_be16(ARPOP_REPLY)) {
-        printk("Invalid ARP reply\n");
-        return -1;
-    }    
+	if (arp->arp.ar_op != sys_cpu_to_be16(ARPOP_REPLY)) {
+		printk("Invalid ARP reply\n");
+		return -1;
+	}
 
-    printk("ARP Request: \n");
-    printk("=== Ethernet Header ===\n");
-    printk("Destination MAC: %02x:%02x:%02x:%02x:%02x:%02x\n", 
-           packet[0], packet[1], packet[2], 
-           packet[3], packet[4], packet[5]);
-    printk("Source MAC: %02x:%02x:%02x:%02x:%02x:%02x\n", 
-           packet[6], packet[7], packet[8], 
-           packet[9], packet[10], packet[11]);
-    
-    uint16_t tx_ethertype = (packet[12] << 8) | packet[13];
-    printk("EtherType: 0x%04x (%s)\n", tx_ethertype, tx_ethertype == 0x0806 ? "ARP" : "Unknown");
-    
-    printk("\n=== ARP Header ===\n");
-    uint16_t tx_hw_type = (packet[14] << 8) | packet[15];
-    printk("Hardware Type: 0x%04x (%s)\n", tx_hw_type, tx_hw_type == 0x0001 ? "Ethernet" : "Unknown");
-    
-    uint16_t tx_proto_type = (packet[16] << 8) | packet[17];
-    printk("Protocol Type: 0x%04x (%s)\n", tx_proto_type, tx_proto_type == 0x0800 ? "IPv4" : "Unknown");
-    
-    uint8_t tx_hw_size = packet[18];
-    uint8_t tx_proto_size = packet[19];
-    printk("Hardware Size: %d bytes\n", tx_hw_size);
-    printk("Protocol Size: %d bytes\n", tx_proto_size);
-    
-    uint16_t tx_operation = (packet[20] << 8) | packet[21];
-    printk("Operation: 0x%04x (%s)\n", tx_operation, tx_operation == 0x0001 ? "Request" : tx_operation == 0x0002 ? "Reply" : "Unknown");
-    
-    printk("\nSender MAC: %02x:%02x:%02x:%02x:%02x:%02x\n", 
-           packet[22], packet[23], packet[24], 
-           packet[25], packet[26], packet[27]);
-    printk("Sender IP: %d.%d.%d.%d\n", 
-           packet[28], packet[29], packet[30], packet[31]);
-    
-    printk("Target MAC: %02x:%02x:%02x:%02x:%02x:%02x\n", 
-           packet[32], packet[33], packet[34], 
-           packet[35], packet[36], packet[37]);
-    printk("Target IP: %d.%d.%d.%d\n", 
-           packet[38], packet[39], packet[40], packet[41]);
+	printk("ARP Request: \n");
+	printk("=== Ethernet Header ===\n");
+	printk("Destination MAC: %02x:%02x:%02x:%02x:%02x:%02x\n", packet[0], packet[1], packet[2],
+	       packet[3], packet[4], packet[5]);
+	printk("Source MAC: %02x:%02x:%02x:%02x:%02x:%02x\n", packet[6], packet[7], packet[8],
+	       packet[9], packet[10], packet[11]);
 
-    return 0;
+	uint16_t tx_ethertype = (packet[12] << 8) | packet[13];
+	printk("EtherType: 0x%04x (%s)\n", tx_ethertype,
+	       tx_ethertype == 0x0806 ? "ARP" : "Unknown");
+
+	printk("\n=== ARP Header ===\n");
+	uint16_t tx_hw_type = (packet[14] << 8) | packet[15];
+	printk("Hardware Type: 0x%04x (%s)\n", tx_hw_type,
+	       tx_hw_type == 0x0001 ? "Ethernet" : "Unknown");
+
+	uint16_t tx_proto_type = (packet[16] << 8) | packet[17];
+	printk("Protocol Type: 0x%04x (%s)\n", tx_proto_type,
+	       tx_proto_type == 0x0800 ? "IPv4" : "Unknown");
+
+	uint8_t tx_hw_size = packet[18];
+	uint8_t tx_proto_size = packet[19];
+	printk("Hardware Size: %d bytes\n", tx_hw_size);
+	printk("Protocol Size: %d bytes\n", tx_proto_size);
+
+	uint16_t tx_operation = (packet[20] << 8) | packet[21];
+	printk("Operation: 0x%04x (%s)\n", tx_operation,
+	       tx_operation == 0x0001   ? "Request"
+	       : tx_operation == 0x0002 ? "Reply"
+					: "Unknown");
+
+	printk("\nSender MAC: %02x:%02x:%02x:%02x:%02x:%02x\n", packet[22], packet[23], packet[24],
+	       packet[25], packet[26], packet[27]);
+	printk("Sender IP: %d.%d.%d.%d\n", packet[28], packet[29], packet[30], packet[31]);
+
+	printk("Target MAC: %02x:%02x:%02x:%02x:%02x:%02x\n", packet[32], packet[33], packet[34],
+	       packet[35], packet[36], packet[37]);
+	printk("Target IP: %d.%d.%d.%d\n", packet[38], packet[39], packet[40], packet[41]);
+
+	return 0;
 }

--- a/samples/t1s/src/arp.h
+++ b/samples/t1s/src/arp.h
@@ -1,0 +1,16 @@
+#ifndef ARP_H
+#define ARP_H
+
+#include <stdint.h>
+
+#include <zephyr/drivers/spi.h>
+#include <zephyr/sys/byteorder.h>
+#include <zephyr/sys/printk.h>
+
+#include "eth.h"
+
+int send_arp_request(const struct spi_dt_spec* spi, const uint8_t my_mac_addr[ETH_ALEN], const uint8_t my_ip_addr[IP_LEN], const uint8_t target_ip_addr[IP_LEN]);
+int receive_arp_reply(const struct spi_dt_spec* spi);
+
+
+#endif  /* ARP_H */

--- a/samples/t1s/src/arp.h
+++ b/samples/t1s/src/arp.h
@@ -9,7 +9,8 @@
 
 #include "eth.h"
 
-int send_arp_request(const struct spi_dt_spec* spi, const uint8_t my_mac_addr[ETH_ALEN], const uint8_t my_ip_addr[IP_LEN], const uint8_t target_ip_addr[IP_LEN]);
-int receive_arp_reply(const struct spi_dt_spec* spi);
+int send_arp_request(const struct spi_dt_spec *spi, const uint8_t my_mac_addr[ETH_ALEN],
+		     const uint8_t my_ip_addr[IP_LEN], const uint8_t target_ip_addr[IP_LEN]);
+int receive_arp_reply(const struct spi_dt_spec *spi);
 
-#endif  /* ARP_H */
+#endif /* ARP_H */

--- a/samples/t1s/src/arp.h
+++ b/samples/t1s/src/arp.h
@@ -12,5 +12,4 @@
 int send_arp_request(const struct spi_dt_spec* spi, const uint8_t my_mac_addr[ETH_ALEN], const uint8_t my_ip_addr[IP_LEN], const uint8_t target_ip_addr[IP_LEN]);
 int receive_arp_reply(const struct spi_dt_spec* spi);
 
-
 #endif  /* ARP_H */

--- a/samples/t1s/src/eth.h
+++ b/samples/t1s/src/eth.h
@@ -1,0 +1,72 @@
+#ifndef ETH_H
+#define ETH_H
+
+#include <stdint.h>
+
+/* FIXME: These are borrowed from linux headers since network features are not available */
+/* Remove this file and use the one included in Zephyr after the issue's fixed */
+
+#define IP_LEN (4)
+#define PACKET_SIZE_ARP (sizeof(struct ethhdr) + sizeof(struct arphdr_ipv4))
+
+#define ETH_ALEN 6
+#define ETH_HLEN 14
+#define ARP_HLEN 28
+
+#define ETH_P_IP	0x0800		/* Internet Protocol packet	*/
+#define ETH_P_ARP	0x0806		/* Address Resolution packet	*/
+
+#define	ARPOP_REQUEST	1		/* ARP request.  */
+#define	ARPOP_REPLY	2		/* ARP reply.  */
+
+#define PF_INET		2	/* IP protocol family.  */
+#define AF_INET PF_INET
+
+struct ethhdr {
+	unsigned char	h_dest[ETH_ALEN];	/* destination eth addr	*/
+	unsigned char	h_source[ETH_ALEN];	/* source ether addr	*/
+	uint16_t		h_proto;		/* packet type ID field	*/
+} __attribute__((packed));
+
+struct ethhdr_l {
+    unsigned char h_dest[ETH_ALEN];
+    unsigned char h_source[ETH_ALEN];
+    unsigned short h_proto;
+};
+
+struct arphdr_l {
+    unsigned short ar_hrd;
+    unsigned short ar_pro;
+    unsigned char ar_hln;
+    unsigned char ar_pln;
+    unsigned short ar_op;
+    unsigned char ar_sha[ETH_ALEN];
+    unsigned char ar_sip[4];
+    unsigned char ar_tha[ETH_ALEN];
+    unsigned char ar_tip[4];
+};
+
+struct arphdr
+  {
+    unsigned short int ar_hrd;		/* Format of hardware address.  */
+    unsigned short int ar_pro;		/* Format of protocol address.  */
+    unsigned char ar_hln;		/* Length of hardware address.  */
+    unsigned char ar_pln;		/* Length of protocol address.  */
+    unsigned short int ar_op;		/* ARP opcode (command).  */
+  };
+
+struct arphdr_ipv4 {
+    struct arphdr arp;
+    uint8_t sender_mac[ETH_ALEN];
+    uint8_t sender_ip[IP_LEN];
+    uint8_t target_mac[ETH_ALEN];
+    uint8_t target_ip[IP_LEN];
+};
+
+// ARP table entry regarding IPv4
+struct arp_entry {
+    uint8_t ip[IP_LEN];
+    uint8_t mac[ETH_ALEN];
+};
+
+#endif /* ETH_H */

--- a/samples/t1s/src/eth.h
+++ b/samples/t1s/src/eth.h
@@ -6,67 +6,66 @@
 /* FIXME: These are borrowed from linux headers since network features are not available */
 /* Remove this file and use the one included in Zephyr after the issue's fixed */
 
-#define IP_LEN (4)
+#define IP_LEN          (4)
 #define PACKET_SIZE_ARP (sizeof(struct ethhdr) + sizeof(struct arphdr_ipv4))
 
 #define ETH_ALEN 6
 #define ETH_HLEN 14
 #define ARP_HLEN 28
 
-#define ETH_P_IP	0x0800		/* Internet Protocol packet	*/
-#define ETH_P_ARP	0x0806		/* Address Resolution packet	*/
+#define ETH_P_IP  0x0800 /* Internet Protocol packet	*/
+#define ETH_P_ARP 0x0806 /* Address Resolution packet	*/
 
-#define	ARPOP_REQUEST	1		/* ARP request.  */
-#define	ARPOP_REPLY	2		/* ARP reply.  */
+#define ARPOP_REQUEST 1 /* ARP request.  */
+#define ARPOP_REPLY   2 /* ARP reply.  */
 
-#define PF_INET		2	/* IP protocol family.  */
+#define PF_INET 2 /* IP protocol family.  */
 #define AF_INET PF_INET
 
 struct ethhdr {
-	unsigned char	h_dest[ETH_ALEN];	/* destination eth addr	*/
-	unsigned char	h_source[ETH_ALEN];	/* source ether addr	*/
-	uint16_t		h_proto;		/* packet type ID field	*/
+	unsigned char h_dest[ETH_ALEN];   /* destination eth addr	*/
+	unsigned char h_source[ETH_ALEN]; /* source ether addr	*/
+	uint16_t h_proto;                 /* packet type ID field	*/
 } __attribute__((packed));
 
 struct ethhdr_l {
-    unsigned char h_dest[ETH_ALEN];
-    unsigned char h_source[ETH_ALEN];
-    unsigned short h_proto;
+	unsigned char h_dest[ETH_ALEN];
+	unsigned char h_source[ETH_ALEN];
+	unsigned short h_proto;
 };
 
 struct arphdr_l {
-    unsigned short ar_hrd;
-    unsigned short ar_pro;
-    unsigned char ar_hln;
-    unsigned char ar_pln;
-    unsigned short ar_op;
-    unsigned char ar_sha[ETH_ALEN];
-    unsigned char ar_sip[4];
-    unsigned char ar_tha[ETH_ALEN];
-    unsigned char ar_tip[4];
+	unsigned short ar_hrd;
+	unsigned short ar_pro;
+	unsigned char ar_hln;
+	unsigned char ar_pln;
+	unsigned short ar_op;
+	unsigned char ar_sha[ETH_ALEN];
+	unsigned char ar_sip[4];
+	unsigned char ar_tha[ETH_ALEN];
+	unsigned char ar_tip[4];
 };
 
-struct arphdr
-  {
-    unsigned short int ar_hrd;		/* Format of hardware address.  */
-    unsigned short int ar_pro;		/* Format of protocol address.  */
-    unsigned char ar_hln;		/* Length of hardware address.  */
-    unsigned char ar_pln;		/* Length of protocol address.  */
-    unsigned short int ar_op;		/* ARP opcode (command).  */
-  };
+struct arphdr {
+	unsigned short int ar_hrd; /* Format of hardware address.  */
+	unsigned short int ar_pro; /* Format of protocol address.  */
+	unsigned char ar_hln;      /* Length of hardware address.  */
+	unsigned char ar_pln;      /* Length of protocol address.  */
+	unsigned short int ar_op;  /* ARP opcode (command).  */
+};
 
 struct arphdr_ipv4 {
-    struct arphdr arp;
-    uint8_t sender_mac[ETH_ALEN];
-    uint8_t sender_ip[IP_LEN];
-    uint8_t target_mac[ETH_ALEN];
-    uint8_t target_ip[IP_LEN];
+	struct arphdr arp;
+	uint8_t sender_mac[ETH_ALEN];
+	uint8_t sender_ip[IP_LEN];
+	uint8_t target_mac[ETH_ALEN];
+	uint8_t target_ip[IP_LEN];
 };
 
 // ARP table entry regarding IPv4
 struct arp_entry {
-    uint8_t ip[IP_LEN];
-    uint8_t mac[ETH_ALEN];
+	uint8_t ip[IP_LEN];
+	uint8_t mac[ETH_ALEN];
 };
 
 #endif /* ETH_H */

--- a/samples/t1s/src/lan8651.c
+++ b/samples/t1s/src/lan8651.c
@@ -40,7 +40,7 @@ static bool t1s_hw_readreg(const struct spi_dt_spec* spi_dev, struct ctrl_cmd_re
     commandheader.ctrl_head_bits.addr = (uint32_t)p_regInfoInput->address;
     commandheader.ctrl_head_bits.len = (uint32_t)(p_regInfoInput->length & 0x7F);
     commandheader.ctrl_head_bits.p = 0;
-    commandheader.ctrl_head_bits.p = ((get_parity(commandheader.ctrl_frame_head) == 0) ? 1 : 0);
+    commandheader.ctrl_head_bits.p = get_parity(commandheader.ctrl_frame_head);
 
     converted_commandheader = sys_cpu_to_be32(commandheader.ctrl_frame_head);
     memcpy(txbuffer, &converted_commandheader, HEADER_SIZE);
@@ -105,7 +105,7 @@ static bool t1s_hw_writereg(const struct spi_dt_spec* spi_dev, struct ctrl_cmd_r
     commandheader.ctrl_head_bits.addr = (uint32_t)p_regData->address;
     commandheader.ctrl_head_bits.len = (uint32_t)(p_regData->length & 0x7F);
     commandheader.ctrl_head_bits.p = 0;
-    commandheader.ctrl_head_bits.p = ((get_parity(commandheader.ctrl_frame_head) == 0) ? 1 : 0);
+    commandheader.ctrl_head_bits.p = get_parity(commandheader.ctrl_frame_head);
 
     converted_commandheader = sys_cpu_to_be32(commandheader.ctrl_frame_head);
     memcpy(txbuffer, &converted_commandheader, HEADER_SIZE);

--- a/samples/t1s/src/lan8651.c
+++ b/samples/t1s/src/lan8651.c
@@ -1,0 +1,421 @@
+#include <stdint.h>
+
+#include <zephyr/drivers/spi.h>
+#include <zephyr/sys/byteorder.h>
+#include <zephyr/sys/printk.h>
+
+#include "lan8651.h"
+
+/* FIXME: These are borrowed from our T1S demo */
+
+uint8_t get_parity(uint32_t valueToCalculateParity) {
+    valueToCalculateParity &= 0xFFFFFFFE;
+    valueToCalculateParity ^= valueToCalculateParity >> 1;
+    valueToCalculateParity ^= valueToCalculateParity >> 2;
+    valueToCalculateParity = ((valueToCalculateParity & 0x11111111) * 0x11111111);
+    return !((valueToCalculateParity >> 28) & 1);
+}
+
+static bool t1s_hw_readreg(const struct spi_dt_spec* spi_dev, struct ctrl_cmd_reg* p_regInfoInput, struct ctrl_cmd_reg* p_readRegData) {
+    const uint8_t ignored_echoedbytes = HEADER_SIZE;
+    bool readstatus = false;
+    uint8_t txbuffer[MAX_REG_DATA_ONECONTROLCMD + HEADER_SIZE + REG_SIZE] = {0};
+    uint8_t rxbuffer[MAX_REG_DATA_ONECONTROLCMD + HEADER_SIZE + REG_SIZE] = {0};
+    uint16_t numberof_bytestosend = 0;
+    union ctrl_header commandheader;
+    union ctrl_header commandheader_echoed;
+    uint32_t converted_commandheader;
+
+    commandheader.ctrl_frame_head = 0;
+    commandheader_echoed.ctrl_frame_head = 0;
+    commandheader.ctrl_head_bits.dnc = DNC_COMMANDTYPE_CONTROL;
+    commandheader.ctrl_head_bits.hdrb = 0;
+    commandheader.ctrl_head_bits.wnr = REG_COMMAND_TYPE_READ; // Read from register
+    if (p_regInfoInput->length != 0) {
+        commandheader.ctrl_head_bits.aid = REG_ADDR_INCREMENT_ENABLE; // Read register continously from given address
+    } else {
+        commandheader.ctrl_head_bits.aid = REG_ADDR_INCREMENT_DISABLE; // Read from same register
+    }
+    commandheader.ctrl_head_bits.mms = (uint32_t)p_regInfoInput->memorymap;
+    commandheader.ctrl_head_bits.addr = (uint32_t)p_regInfoInput->address;
+    commandheader.ctrl_head_bits.len = (uint32_t)(p_regInfoInput->length & 0x7F);
+    commandheader.ctrl_head_bits.p = 0;
+    commandheader.ctrl_head_bits.p = ((get_parity(commandheader.ctrl_frame_head) == 0) ? 1 : 0);
+
+    converted_commandheader = sys_cpu_to_be32(commandheader.ctrl_frame_head);
+    memcpy(txbuffer, &converted_commandheader, HEADER_SIZE);
+
+    numberof_bytestosend =
+        HEADER_SIZE + ((commandheader.ctrl_head_bits.len + 1) * REG_SIZE) +
+        ignored_echoedbytes; // Added extra 4 bytes because first 4 bytes during reception shall be ignored
+
+	struct spi_buf tx_buf = {.buf = txbuffer, .len = numberof_bytestosend};
+	const struct spi_buf_set tx_buf_set = {.buffers = &tx_buf, .count = 1};
+	struct spi_buf rx_buf = {.buf = rxbuffer, .len = numberof_bytestosend};
+	const struct spi_buf_set rx_buf_set = {.buffers = &rx_buf, .count = 1};
+    spi_transceive_dt(spi_dev, &tx_buf_set, &rx_buf_set);
+
+    memcpy((uint8_t*)&commandheader_echoed.ctrl_frame_head, &rxbuffer[ignored_echoedbytes], HEADER_SIZE);
+    commandheader_echoed.ctrl_frame_head = sys_be32_to_cpu(commandheader_echoed.ctrl_frame_head);
+
+    if (commandheader_echoed.ctrl_head_bits.hdrb != 1) // if MACPHY received header with parity error then it will be 1
+    {
+        if (commandheader.ctrl_head_bits.len == 0) {
+            memcpy((uint8_t*)&p_readRegData->databuffer[0], &(rxbuffer[ignored_echoedbytes + HEADER_SIZE]), REG_SIZE);
+            p_readRegData->databuffer[0] = sys_be32_to_cpu(p_readRegData->databuffer[1]);
+        } else {
+            for (int regCount = 0; regCount <= commandheader.ctrl_head_bits.len; regCount++) {
+                memcpy((uint8_t*)&p_readRegData->databuffer[regCount],
+                       &rxbuffer[ignored_echoedbytes + HEADER_SIZE + (REG_SIZE * regCount)], REG_SIZE);
+                p_readRegData->databuffer[regCount] = sys_be32_to_cpu(p_readRegData->databuffer[regCount]);
+            }
+        }
+        readstatus = true;
+    } else {
+        // TODO: Error handling if MACPHY received with header parity error
+        printk("Parity Error READMACPHYReg header value : 0x%08x\n", commandheader_echoed.ctrl_frame_head);
+    }
+
+    return readstatus;
+}
+
+static bool t1s_hw_writereg(const struct spi_dt_spec* spi_dev, struct ctrl_cmd_reg* p_regData) {
+    uint8_t numberof_bytestosend = 0;
+    uint8_t numberof_registerstosend = 0;
+    bool writestatus = true;
+    bool execution_status = false;
+    const uint8_t ignored_echoedbytes = HEADER_SIZE;
+    uint8_t txbuffer[MAX_PAYLOAD_BYTE + HEADER_SIZE] = {0};
+    uint8_t rxbuffer[MAX_PAYLOAD_BYTE + HEADER_SIZE + 8] = {0};
+    union ctrl_header commandheader;
+    union ctrl_header commandheader_echoed;
+    uint32_t converted_commandheader;
+
+    commandheader.ctrl_frame_head = commandheader_echoed.ctrl_frame_head = 0;
+
+    commandheader.ctrl_head_bits.dnc = DNC_COMMANDTYPE_CONTROL;
+    commandheader.ctrl_head_bits.hdrb = 0;
+    commandheader.ctrl_head_bits.wnr = REG_COMMAND_TYPE_WRITE; // Write into register
+    if (p_regData->length != 0) {
+        commandheader.ctrl_head_bits.aid = REG_ADDR_INCREMENT_ENABLE; // Write register continously from given address
+    } else {
+        commandheader.ctrl_head_bits.aid = REG_ADDR_INCREMENT_DISABLE; // Write into same register
+    }
+    commandheader.ctrl_head_bits.mms = (uint32_t)(p_regData->memorymap & 0x0F);
+    commandheader.ctrl_head_bits.addr = (uint32_t)p_regData->address;
+    commandheader.ctrl_head_bits.len = (uint32_t)(p_regData->length & 0x7F);
+    commandheader.ctrl_head_bits.p = 0;
+    commandheader.ctrl_head_bits.p = ((get_parity(commandheader.ctrl_frame_head) == 0) ? 1 : 0);
+
+    converted_commandheader = sys_cpu_to_be32(commandheader.ctrl_frame_head);
+    memcpy(txbuffer, &converted_commandheader, HEADER_SIZE);
+
+    numberof_registerstosend = commandheader.ctrl_head_bits.len + 1;
+    for (uint8_t controlRegIndex = 0; controlRegIndex < numberof_registerstosend; controlRegIndex++) {
+        uint32_t data = sys_cpu_to_be32(p_regData->databuffer[controlRegIndex]);
+        memcpy(&txbuffer[HEADER_SIZE + controlRegIndex * REG_SIZE], &data, sizeof(uint32_t));
+    }
+
+    numberof_bytestosend =
+        HEADER_SIZE + ((commandheader.ctrl_head_bits.len + 1) * REG_SIZE) +
+        ignored_echoedbytes; // Added extra 4 bytes because last 4 bytes of payload will be ignored by MACPHY
+
+	struct spi_buf tx_buf = {.buf = txbuffer, .len = numberof_bytestosend};
+	const struct spi_buf_set tx_buf_set = {.buffers = &tx_buf, .count = 1};
+	struct spi_buf rx_buf = {.buf = rxbuffer, .len = numberof_bytestosend};
+	const struct spi_buf_set rx_buf_set = {.buffers = &rx_buf, .count = 1};
+    spi_transceive_dt(spi_dev, &tx_buf_set, &rx_buf_set);
+
+    memcpy((uint8_t*)&commandheader_echoed.ctrl_frame_head, &rxbuffer[ignored_echoedbytes], HEADER_SIZE);
+    commandheader_echoed.ctrl_frame_head = sys_be32_to_cpu(commandheader_echoed.ctrl_frame_head);
+    // TODO: check this logic and modify it if needed
+    if (commandheader.ctrl_head_bits.mms == 0) {
+        struct ctrl_cmd_reg readreg_infoinput;
+        struct ctrl_cmd_reg readreg_data;
+
+        // Reads CONFIG0 register from MMS 0
+        readreg_infoinput.memorymap = MMS0;
+        readreg_infoinput.length = 0;
+        readreg_infoinput.address = OA_CONFIG0;
+        memset(&readreg_infoinput.databuffer[0], 0, MAX_REG_DATA_ONECHUNK);
+
+        execution_status = t1s_hw_readreg(spi_dev, &readreg_infoinput, &readreg_data);
+        if (execution_status == false) {
+            printk("Reading CONFIG0 reg failed after writing (inside WriteReg)\n");
+        } else {
+            printk("CONFIG0 reg value is 0x%08x in WriteReg function\n", readreg_data.databuffer[0]);
+        }
+    }
+
+    return writestatus;
+}
+
+uint32_t write_register(const struct spi_dt_spec* spi_dev, uint8_t mms, uint16_t address, uint32_t data) {
+    struct ctrl_cmd_reg writereg_input;
+    bool execution_status = false;
+    writereg_input.memorymap = mms;
+    writereg_input.length = 0;
+    writereg_input.address = address;
+    writereg_input.databuffer[0] = data;
+
+    execution_status = t1s_hw_writereg(spi_dev, &writereg_input);
+    if (execution_status == true) {
+        return writereg_input.databuffer[0];
+    } else {
+        printk("ERROR: Register Write failed at MMS %d, Address %4x\n", mms, address);
+        return 0;
+    }
+}
+
+uint32_t read_register(const struct spi_dt_spec* spi_dev, uint8_t mms, uint16_t address) {
+    bool execution_status = false;
+    struct ctrl_cmd_reg readreg_infoinput;
+    struct ctrl_cmd_reg readreg_data;
+    readreg_infoinput.memorymap = mms;
+    readreg_infoinput.length = 0;
+    readreg_infoinput.address = address;
+
+    execution_status = t1s_hw_readreg(spi_dev, &readreg_infoinput, &readreg_data);
+    if (execution_status == true) {
+        return readreg_data.databuffer[0];
+    } else {
+        printk("ERROR: Register Read failed at MMS %d, Address %4x\n", mms, address);
+        return 0;
+    }
+}
+
+static void set_macphy_register(const struct spi_dt_spec* spi_dev) {
+    uint8_t value1 = read_register(spi_dev, 0x04, 0x1F);
+    int8_t offset1;
+    if ((value1 & 0x10) != 0) {
+        offset1 = (int8_t)((uint8_t)value1 - 0x20);
+    } else {
+        offset1 = (int8_t)value1;
+    }
+
+    uint8_t value2 = read_register(spi_dev, 0x08, 0x1F);
+    int8_t offset2;
+    if ((value2 & 0x10) != 0) {
+        offset2 = (int8_t)((uint8_t)value2 - 0x20);
+    } else {
+        offset2 = (int8_t)value2;
+    }
+
+    uint16_t cfgparam1 = (uint16_t)(((9 + offset1) & 0x3F) << 10) | (uint16_t)(((14 + offset1) & 0x3F) << 4) | 0x03;
+    uint16_t cfgparam2 = (uint16_t)(((40 + offset2) & 0x3F) << 10);
+
+    write_register(spi_dev, MMS4, 0x00D0, 0x3F31);
+    write_register(spi_dev, MMS4, 0x00E0, 0xC000);
+    write_register(spi_dev, MMS4, 0x0084, cfgparam1);
+    write_register(spi_dev, MMS4, 0x008A, cfgparam2);
+    write_register(spi_dev, MMS4, 0x00E9, 0x9E50);
+    write_register(spi_dev, MMS4, 0x00F5, 0x1CF8);
+    write_register(spi_dev, MMS4, 0x00F4, 0xC020);
+    write_register(spi_dev, MMS4, 0x00F8, 0xB900);
+    write_register(spi_dev, MMS4, 0x00F9, 0x4E53);
+    write_register(spi_dev, MMS4, 0x0081, 0x0080);
+    write_register(spi_dev, MMS4, 0x0091, 0x9660);
+    write_register(spi_dev, MMS4, 0x0077, 0x0028);
+    write_register(spi_dev, MMS4, 0x0043, 0x00FF);
+    write_register(spi_dev, MMS4, 0x0044, 0xFFFF);
+    write_register(spi_dev, MMS4, 0x0045, 0x0000);
+    write_register(spi_dev, MMS4, 0x0053, 0x00FF);
+    write_register(spi_dev, MMS4, 0x0054, 0xFFFF);
+    write_register(spi_dev, MMS4, 0x0055, 0x0000);
+    write_register(spi_dev, MMS4, 0x0040, 0x0002);
+    write_register(spi_dev, MMS4, 0x0050, 0x0002);
+}
+
+int set_register(const struct spi_dt_spec* spi_dev, int mode) {
+    uint32_t regval;
+
+    /* Read OA_STATUS0 */
+    regval = read_register(spi_dev, MMS0, OA_STATUS0);
+    printk("OA_STATUS0: 0x%08x\n", regval);
+
+    /* Write 1 to RESETC bit of OA_STATUS0 */
+    regval |= (1 << 6);
+    write_register(spi_dev, MMS0, OA_STATUS0, regval);
+    printk("OA_STATUS0: 0x%08x\n", regval);
+
+    regval = read_register(spi_dev, MMS4, CDCTL0);
+    write_register(spi_dev, MMS4, CDCTL0, regval | (1 << 15)); // Initial logic (disable collision detection)
+    printk("CDCTL0: 0x%08x\n", regval);
+
+    // PLCA Configuration based on mode
+    // TODO: This process is temporary and assumes that there are only two nodes.
+    // TODO: Should be changed to get node info. from the command line.
+    if (mode == PLCA_MODE_COORDINATOR) {
+        write_register(spi_dev, MMS4, PLCA_CTRL1, 0x00000800); // Coordinator(node 0), 2 nodes
+        write_register(spi_dev, MMS1, MAC_SAB1, 0x11111111);   // Configure MAC Address (Temporary)
+        write_register(spi_dev, MMS1, MAC_SAT1, 0x00001111);   // Configure MAC Address (Temporary)
+        printk("PLCA_CTRL1: 0x%08x\n", read_register(spi_dev, MMS4, PLCA_CTRL1));
+        printk("MAC_SAB1: 0x%08x\n", read_register(spi_dev, MMS1, MAC_SAB1));
+        printk("MAC_SAT1: 0x%08x\n", read_register(spi_dev, MMS1, MAC_SAT1));
+    } else if (mode == PLCA_MODE_FOLLOWER) {
+        write_register(spi_dev, MMS4, PLCA_CTRL1, 0x00000801); // Follower, node 1
+        write_register(spi_dev, MMS1, MAC_SAB1, 0x22222222);   // Configure MAC Address (Temporary)
+        write_register(spi_dev, MMS1, MAC_SAT1, 0x00002222);   // Configure MAC Address (Temporary)
+        printk("PLCA_CTRL1: 0x%08x\n", read_register(spi_dev, MMS4, PLCA_CTRL1));
+        printk("MAC_SAB1: 0x%08x\n", read_register(spi_dev, MMS1, MAC_SAB1));
+        printk("MAC_SAT1: 0x%08x\n", read_register(spi_dev, MMS1, MAC_SAT1));
+    } else {
+        printk("Invalid mode: %d\n", mode);
+        return false;
+    }
+    set_macphy_register(spi_dev); // AN_LAN865x-Configuration
+
+    write_register(spi_dev, MMS4, PLCA_CTRL0, 0x00008000); // Enable PLCA
+    write_register(spi_dev, MMS1, MAC_NCFGR, 0x000000C0);  // Enable unicast, multicast
+    write_register(spi_dev, MMS1, MAC_NCR, 0x0000000C);    // Enable MACPHY TX, RX
+    printk("PLCA_CTRL0: 0x%08x\n", read_register(spi_dev, MMS4, PLCA_CTRL0));
+    printk("MAC_NCFGR: 0x%08x\n", read_register(spi_dev, MMS1, MAC_NCFGR));
+    printk("MAC_NCR: 0x%08x\n", read_register(spi_dev, MMS1, MAC_NCR));
+
+    /* Read OA_CONFIG0 */
+    regval = read_register(spi_dev, MMS0, OA_CONFIG0);
+    printk("OA_CONFIG0: 0x%08x\n", regval);
+
+    /* Set SYNC bit of OA_CONFIG0 */
+    regval |= (1 << 15);
+    regval &= ~(0x7);
+    regval |= (0x6);
+    write_register(spi_dev, MMS0, OA_CONFIG0, regval);
+    printk("OA_CONFIG0: 0x%08x\n", regval);
+
+    /* Read OA_STATUS0 */
+    regval = read_register(spi_dev, MMS0, OA_STATUS0);
+    printk("OA_STATUS0: 0x%08x\n", regval);
+
+    /* Clear RESETC bit of OA_STATUS0 */
+    regval &= ~(1UL << 6);
+    write_register(spi_dev, MMS0, OA_STATUS0, regval);
+    printk("OA_STATUS0: 0x%08x\n", regval);
+
+    return true;
+}
+
+int send_packet(const struct spi_dt_spec* spi_dev, const uint8_t* data, uint16_t length) {
+    if (length > MAX_PACKET_SIZE) {
+        printk("Packet size is too large: %d\n", length);
+        return -1;
+    }
+
+    uint8_t tx_buffer[HEADER_SIZE + MAX_PAYLOAD_BYTE];
+    uint8_t rx_buffer[MAX_PAYLOAD_BYTE + FOOTER_SIZE];
+
+    union data_header data_header;
+    uint32_t be_header;
+
+    uint32_t chunk_count = length / MAX_PAYLOAD_BYTE;
+    if (length % 64) {
+        chunk_count++;
+    }
+
+    uint32_t chunk_size = MAX_PAYLOAD_BYTE;
+
+    data_header.tx_header_bits.dnc = DNC_COMMANDTYPE_DATA;
+    data_header.tx_header_bits.norx = NORX_NO_RECEIVE;
+    data_header.tx_header_bits.dv = DV_DATA_VALID;
+    for (uint32_t i = 0; i < chunk_count; i++) {
+        data_header.tx_header_bits.sv = SV_START_INVALID;
+        data_header.tx_header_bits.ev = EV_END_INVALID;
+        data_header.tx_header_bits.ebo = 0;
+
+        if (i == 0) {  // First chunk
+            data_header.tx_header_bits.sv = SV_START_VALID;
+        } if (i == chunk_count - 1) {
+            chunk_size = length % MAX_PAYLOAD_BYTE;
+            if (chunk_size == 0) chunk_size = MAX_PAYLOAD_BYTE;
+            data_header.tx_header_bits.ev = EV_END_VALID;
+            data_header.tx_header_bits.ebo = chunk_size - 1;
+        }
+
+        data_header.tx_header_bits.p = 0;
+        data_header.tx_header_bits.p = get_parity(data_header.data_frame_head);
+
+        be_header = sys_cpu_to_be32(data_header.data_frame_head);
+        memcpy(tx_buffer, &be_header, HEADER_SIZE);
+        memcpy(tx_buffer + HEADER_SIZE, data + i * MAX_PAYLOAD_BYTE, MAX_PAYLOAD_BYTE);
+
+        struct spi_buf tx_buf = {.buf = tx_buffer, .len = HEADER_SIZE + MAX_PAYLOAD_BYTE};
+        const struct spi_buf_set tx_buf_set = {.buffers = &tx_buf, .count = 1};
+        struct spi_buf rx_buf = {.buf = rx_buffer, .len = MAX_PAYLOAD_BYTE + FOOTER_SIZE};
+        const struct spi_buf_set rx_buf_set = {.buffers = &rx_buf, .count = 1};
+        if (spi_transceive_dt(spi_dev, &tx_buf_set, &rx_buf_set) != 0) {
+            printk("SPI transceive failed while sending packet\n");
+            return -1;
+        }
+    }
+
+    return 0;
+}
+
+int receive_packet(const struct spi_dt_spec* spi_dev, uint8_t* data, uint16_t* length) {
+    uint8_t tx_buffer[HEADER_SIZE + MAX_PAYLOAD_BYTE];
+    uint8_t rx_buffer[MAX_PAYLOAD_BYTE + FOOTER_SIZE];
+
+    union data_header data_header;
+    union data_footer data_footer;
+    uint32_t be_header;
+    uint32_t be_footer;
+    size_t data_offset = 0;
+    size_t chunk_size = MAX_PAYLOAD_BYTE;
+    bool finished = false;
+
+    *length = 0;
+    
+    data_header.tx_header_bits.dnc = DNC_COMMANDTYPE_DATA;
+    data_header.tx_header_bits.norx = NORX_RECEIVE;
+    data_header.tx_header_bits.dv = DV_DATA_INVALID;
+    data_header.tx_header_bits.sv = SV_START_INVALID;
+    data_header.tx_header_bits.ev = EV_END_INVALID;
+    data_header.tx_header_bits.ebo = 0;
+    data_header.tx_header_bits.p = get_parity(data_header.data_frame_head);
+    while (*length < MAX_PACKET_SIZE && !finished) {
+        be_header = sys_cpu_to_be32(data_header.data_frame_head);
+        memcpy(tx_buffer, &be_header, HEADER_SIZE);
+
+        struct spi_buf tx_buf = {.buf = tx_buffer, .len = HEADER_SIZE + MAX_PAYLOAD_BYTE};
+        const struct spi_buf_set tx_buf_set = {.buffers = &tx_buf, .count = 1};
+        struct spi_buf rx_buf = {.buf = rx_buffer, .len = MAX_PAYLOAD_BYTE + FOOTER_SIZE};
+        const struct spi_buf_set rx_buf_set = {.buffers = &rx_buf, .count = 1};
+        if (spi_transceive_dt(spi_dev, &tx_buf_set, &rx_buf_set) != 0) {
+            printk("SPI transceive failed while receiving packet\n");
+            return -1;
+        }
+
+        be_footer = *((uint32_t*)(rx_buffer + MAX_PAYLOAD_BYTE));
+        data_footer.data_frame_foot = sys_be32_to_cpu(be_footer);
+
+        if (data_footer.rx_footer_bits.p != get_parity(data_footer.data_frame_foot)) {
+            printk("Parity error while receiving packet\n");
+            return -1;
+        }
+
+        if (*length == 0) {  /* First chunk */
+            if (data_footer.rx_footer_bits.dv == DV_DATA_INVALID) {
+                /* No data to be received */
+                return 0;
+            }
+
+            if (data_footer.rx_footer_bits.sv == SV_START_INVALID) {
+                printk("Invalid start of the packet\n");
+                return -1;
+            }
+
+            data_offset = (data_footer.rx_footer_bits.swo * 4);  /* 4 bytes per word */
+        }
+        
+        if (data_footer.rx_footer_bits.ev == EV_END_VALID) {  /* Last chunk */
+            chunk_size = data_footer.rx_footer_bits.ebo + 1;
+            finished = true;
+        }
+
+        memcpy(data + *length, rx_buffer + data_offset, chunk_size - data_offset);
+        *length += chunk_size - data_offset;
+        data_offset = 0;
+    }
+
+    return 0;
+}

--- a/samples/t1s/src/lan8651.c
+++ b/samples/t1s/src/lan8651.c
@@ -5,6 +5,7 @@
 #include <zephyr/sys/printk.h>
 
 #include "lan8651.h"
+#include "spi.h"
 
 /* FIXME: These are borrowed from our T1S demo */
 
@@ -49,11 +50,7 @@ static bool t1s_hw_readreg(const struct spi_dt_spec* spi_dev, struct ctrl_cmd_re
         HEADER_SIZE + ((commandheader.ctrl_head_bits.len + 1) * REG_SIZE) +
         ignored_echoedbytes; // Added extra 4 bytes because first 4 bytes during reception shall be ignored
 
-	struct spi_buf tx_buf = {.buf = txbuffer, .len = numberof_bytestosend};
-	const struct spi_buf_set tx_buf_set = {.buffers = &tx_buf, .count = 1};
-	struct spi_buf rx_buf = {.buf = rxbuffer, .len = numberof_bytestosend};
-	const struct spi_buf_set rx_buf_set = {.buffers = &rx_buf, .count = 1};
-    spi_transceive_dt(spi_dev, &tx_buf_set, &rx_buf_set);
+    transceive(txbuffer, rxbuffer, numberof_bytestosend);
 
     memcpy((uint8_t*)&commandheader_echoed.ctrl_frame_head, &rxbuffer[ignored_echoedbytes], HEADER_SIZE);
     commandheader_echoed.ctrl_frame_head = sys_be32_to_cpu(commandheader_echoed.ctrl_frame_head);
@@ -120,11 +117,7 @@ static bool t1s_hw_writereg(const struct spi_dt_spec* spi_dev, struct ctrl_cmd_r
         HEADER_SIZE + ((commandheader.ctrl_head_bits.len + 1) * REG_SIZE) +
         ignored_echoedbytes; // Added extra 4 bytes because last 4 bytes of payload will be ignored by MACPHY
 
-	struct spi_buf tx_buf = {.buf = txbuffer, .len = numberof_bytestosend};
-	const struct spi_buf_set tx_buf_set = {.buffers = &tx_buf, .count = 1};
-	struct spi_buf rx_buf = {.buf = rxbuffer, .len = numberof_bytestosend};
-	const struct spi_buf_set rx_buf_set = {.buffers = &rx_buf, .count = 1};
-    spi_transceive_dt(spi_dev, &tx_buf_set, &rx_buf_set);
+    transceive(txbuffer, rxbuffer, numberof_bytestosend);
 
     memcpy((uint8_t*)&commandheader_echoed.ctrl_frame_head, &rxbuffer[ignored_echoedbytes], HEADER_SIZE);
     commandheader_echoed.ctrl_frame_head = sys_be32_to_cpu(commandheader_echoed.ctrl_frame_head);

--- a/samples/t1s/src/lan8651.c
+++ b/samples/t1s/src/lan8651.c
@@ -9,406 +9,446 @@
 
 /* FIXME: These are borrowed from our T1S demo */
 
-uint8_t get_parity(uint32_t valueToCalculateParity) {
-    valueToCalculateParity &= 0xFFFFFFFE;
-    valueToCalculateParity ^= valueToCalculateParity >> 1;
-    valueToCalculateParity ^= valueToCalculateParity >> 2;
-    valueToCalculateParity = ((valueToCalculateParity & 0x11111111) * 0x11111111);
-    return !((valueToCalculateParity >> 28) & 1);
+uint8_t get_parity(uint32_t valueToCalculateParity)
+{
+	valueToCalculateParity &= 0xFFFFFFFE;
+	valueToCalculateParity ^= valueToCalculateParity >> 1;
+	valueToCalculateParity ^= valueToCalculateParity >> 2;
+	valueToCalculateParity = ((valueToCalculateParity & 0x11111111) * 0x11111111);
+	return !((valueToCalculateParity >> 28) & 1);
 }
 
-static bool t1s_hw_readreg(const struct spi_dt_spec* spi_dev, struct ctrl_cmd_reg* p_regInfoInput, struct ctrl_cmd_reg* p_readRegData) {
-    const uint8_t ignored_echoedbytes = HEADER_SIZE;
-    bool readstatus = false;
-    uint8_t txbuffer[MAX_REG_DATA_ONECONTROLCMD + HEADER_SIZE + REG_SIZE] = {0};
-    uint8_t rxbuffer[MAX_REG_DATA_ONECONTROLCMD + HEADER_SIZE + REG_SIZE] = {0};
-    uint16_t numberof_bytestosend = 0;
-    union ctrl_header commandheader;
-    union ctrl_header commandheader_echoed;
-    uint32_t converted_commandheader;
+static bool t1s_hw_readreg(const struct spi_dt_spec *spi_dev, struct ctrl_cmd_reg *p_regInfoInput,
+			   struct ctrl_cmd_reg *p_readRegData)
+{
+	const uint8_t ignored_echoedbytes = HEADER_SIZE;
+	bool readstatus = false;
+	uint8_t txbuffer[MAX_REG_DATA_ONECONTROLCMD + HEADER_SIZE + REG_SIZE] = {0};
+	uint8_t rxbuffer[MAX_REG_DATA_ONECONTROLCMD + HEADER_SIZE + REG_SIZE] = {0};
+	uint16_t numberof_bytestosend = 0;
+	union ctrl_header commandheader;
+	union ctrl_header commandheader_echoed;
+	uint32_t converted_commandheader;
 
-    commandheader.ctrl_frame_head = 0;
-    commandheader_echoed.ctrl_frame_head = 0;
-    commandheader.ctrl_head_bits.dnc = DNC_COMMANDTYPE_CONTROL;
-    commandheader.ctrl_head_bits.hdrb = 0;
-    commandheader.ctrl_head_bits.wnr = REG_COMMAND_TYPE_READ; // Read from register
-    if (p_regInfoInput->length != 0) {
-        commandheader.ctrl_head_bits.aid = REG_ADDR_INCREMENT_ENABLE; // Read register continously from given address
-    } else {
-        commandheader.ctrl_head_bits.aid = REG_ADDR_INCREMENT_DISABLE; // Read from same register
-    }
-    commandheader.ctrl_head_bits.mms = (uint32_t)p_regInfoInput->memorymap;
-    commandheader.ctrl_head_bits.addr = (uint32_t)p_regInfoInput->address;
-    commandheader.ctrl_head_bits.len = (uint32_t)(p_regInfoInput->length & 0x7F);
-    commandheader.ctrl_head_bits.p = 0;
-    commandheader.ctrl_head_bits.p = get_parity(commandheader.ctrl_frame_head);
+	commandheader.ctrl_frame_head = 0;
+	commandheader_echoed.ctrl_frame_head = 0;
+	commandheader.ctrl_head_bits.dnc = DNC_COMMANDTYPE_CONTROL;
+	commandheader.ctrl_head_bits.hdrb = 0;
+	commandheader.ctrl_head_bits.wnr = REG_COMMAND_TYPE_READ; // Read from register
+	if (p_regInfoInput->length != 0) {
+		commandheader.ctrl_head_bits.aid =
+			REG_ADDR_INCREMENT_ENABLE; // Read register continously from given address
+	} else {
+		commandheader.ctrl_head_bits.aid =
+			REG_ADDR_INCREMENT_DISABLE; // Read from same register
+	}
+	commandheader.ctrl_head_bits.mms = (uint32_t)p_regInfoInput->memorymap;
+	commandheader.ctrl_head_bits.addr = (uint32_t)p_regInfoInput->address;
+	commandheader.ctrl_head_bits.len = (uint32_t)(p_regInfoInput->length & 0x7F);
+	commandheader.ctrl_head_bits.p = 0;
+	commandheader.ctrl_head_bits.p = get_parity(commandheader.ctrl_frame_head);
 
-    converted_commandheader = sys_cpu_to_be32(commandheader.ctrl_frame_head);
-    memcpy(txbuffer, &converted_commandheader, HEADER_SIZE);
+	converted_commandheader = sys_cpu_to_be32(commandheader.ctrl_frame_head);
+	memcpy(txbuffer, &converted_commandheader, HEADER_SIZE);
 
-    numberof_bytestosend =
-        HEADER_SIZE + ((commandheader.ctrl_head_bits.len + 1) * REG_SIZE) +
-        ignored_echoedbytes; // Added extra 4 bytes because first 4 bytes during reception shall be ignored
+	numberof_bytestosend = HEADER_SIZE + ((commandheader.ctrl_head_bits.len + 1) * REG_SIZE) +
+			       ignored_echoedbytes; // Added extra 4 bytes because first 4 bytes
+						    // during reception shall be ignored
 
-    transceive(txbuffer, rxbuffer, numberof_bytestosend);
+	transceive(txbuffer, rxbuffer, numberof_bytestosend);
 
-    memcpy((uint8_t*)&commandheader_echoed.ctrl_frame_head, &rxbuffer[ignored_echoedbytes], HEADER_SIZE);
-    commandheader_echoed.ctrl_frame_head = sys_be32_to_cpu(commandheader_echoed.ctrl_frame_head);
+	memcpy((uint8_t *)&commandheader_echoed.ctrl_frame_head, &rxbuffer[ignored_echoedbytes],
+	       HEADER_SIZE);
+	commandheader_echoed.ctrl_frame_head =
+		sys_be32_to_cpu(commandheader_echoed.ctrl_frame_head);
 
-    if (commandheader_echoed.ctrl_head_bits.hdrb != 1) // if MACPHY received header with parity error then it will be 1
-    {
-        if (commandheader.ctrl_head_bits.len == 0) {
-            memcpy((uint8_t*)&p_readRegData->databuffer[0], &(rxbuffer[ignored_echoedbytes + HEADER_SIZE]), REG_SIZE);
-            p_readRegData->databuffer[0] = sys_be32_to_cpu(p_readRegData->databuffer[0]);
-        } else {
-            for (int regCount = 0; regCount <= commandheader.ctrl_head_bits.len; regCount++) {
-                memcpy((uint8_t*)&p_readRegData->databuffer[regCount],
-                       &rxbuffer[ignored_echoedbytes + HEADER_SIZE + (REG_SIZE * regCount)], REG_SIZE);
-                p_readRegData->databuffer[regCount] = sys_be32_to_cpu(p_readRegData->databuffer[regCount]);
-            }
-        }
-        readstatus = true;
-    } else {
-        // TODO: Error handling if MACPHY received with header parity error
-        printk("Parity Error READMACPHYReg header value : 0x%08x\n", commandheader_echoed.ctrl_frame_head);
-    }
+	if (commandheader_echoed.ctrl_head_bits.hdrb !=
+	    1) // if MACPHY received header with parity error then it will be 1
+	{
+		if (commandheader.ctrl_head_bits.len == 0) {
+			memcpy((uint8_t *)&p_readRegData->databuffer[0],
+			       &(rxbuffer[ignored_echoedbytes + HEADER_SIZE]), REG_SIZE);
+			p_readRegData->databuffer[0] =
+				sys_be32_to_cpu(p_readRegData->databuffer[0]);
+		} else {
+			for (int regCount = 0; regCount <= commandheader.ctrl_head_bits.len;
+			     regCount++) {
+				memcpy((uint8_t *)&p_readRegData->databuffer[regCount],
+				       &rxbuffer[ignored_echoedbytes + HEADER_SIZE +
+						 (REG_SIZE * regCount)],
+				       REG_SIZE);
+				p_readRegData->databuffer[regCount] =
+					sys_be32_to_cpu(p_readRegData->databuffer[regCount]);
+			}
+		}
+		readstatus = true;
+	} else {
+		// TODO: Error handling if MACPHY received with header parity error
+		printk("Parity Error READMACPHYReg header value : 0x%08x\n",
+		       commandheader_echoed.ctrl_frame_head);
+	}
 
-    return readstatus;
+	return readstatus;
 }
 
-static bool t1s_hw_writereg(const struct spi_dt_spec* spi_dev, struct ctrl_cmd_reg* p_regData) {
-    uint8_t numberof_bytestosend = 0;
-    uint8_t numberof_registerstosend = 0;
-    bool writestatus = true;
-    bool execution_status = false;
-    const uint8_t ignored_echoedbytes = HEADER_SIZE;
-    uint8_t txbuffer[MAX_PAYLOAD_BYTE + HEADER_SIZE] = {0};
-    uint8_t rxbuffer[MAX_PAYLOAD_BYTE + HEADER_SIZE] = {0};
-    union ctrl_header commandheader;
-    union ctrl_header commandheader_echoed;
-    uint32_t converted_commandheader;
+static bool t1s_hw_writereg(const struct spi_dt_spec *spi_dev, struct ctrl_cmd_reg *p_regData)
+{
+	uint8_t numberof_bytestosend = 0;
+	uint8_t numberof_registerstosend = 0;
+	bool writestatus = true;
+	bool execution_status = false;
+	const uint8_t ignored_echoedbytes = HEADER_SIZE;
+	uint8_t txbuffer[MAX_PAYLOAD_BYTE + HEADER_SIZE] = {0};
+	uint8_t rxbuffer[MAX_PAYLOAD_BYTE + HEADER_SIZE] = {0};
+	union ctrl_header commandheader;
+	union ctrl_header commandheader_echoed;
+	uint32_t converted_commandheader;
 
-    commandheader.ctrl_frame_head = commandheader_echoed.ctrl_frame_head = 0;
+	commandheader.ctrl_frame_head = commandheader_echoed.ctrl_frame_head = 0;
 
-    commandheader.ctrl_head_bits.dnc = DNC_COMMANDTYPE_CONTROL;
-    commandheader.ctrl_head_bits.hdrb = 0;
-    commandheader.ctrl_head_bits.wnr = REG_COMMAND_TYPE_WRITE; // Write into register
-    if (p_regData->length != 0) {
-        commandheader.ctrl_head_bits.aid = REG_ADDR_INCREMENT_ENABLE; // Write register continously from given address
-    } else {
-        commandheader.ctrl_head_bits.aid = REG_ADDR_INCREMENT_DISABLE; // Write into same register
-    }
-    commandheader.ctrl_head_bits.mms = (uint32_t)(p_regData->memorymap & 0x0F);
-    commandheader.ctrl_head_bits.addr = (uint32_t)p_regData->address;
-    commandheader.ctrl_head_bits.len = (uint32_t)(p_regData->length & 0x7F);
-    commandheader.ctrl_head_bits.p = 0;
-    commandheader.ctrl_head_bits.p = get_parity(commandheader.ctrl_frame_head);
+	commandheader.ctrl_head_bits.dnc = DNC_COMMANDTYPE_CONTROL;
+	commandheader.ctrl_head_bits.hdrb = 0;
+	commandheader.ctrl_head_bits.wnr = REG_COMMAND_TYPE_WRITE; // Write into register
+	if (p_regData->length != 0) {
+		commandheader.ctrl_head_bits.aid =
+			REG_ADDR_INCREMENT_ENABLE; // Write register continously from given address
+	} else {
+		commandheader.ctrl_head_bits.aid =
+			REG_ADDR_INCREMENT_DISABLE; // Write into same register
+	}
+	commandheader.ctrl_head_bits.mms = (uint32_t)(p_regData->memorymap & 0x0F);
+	commandheader.ctrl_head_bits.addr = (uint32_t)p_regData->address;
+	commandheader.ctrl_head_bits.len = (uint32_t)(p_regData->length & 0x7F);
+	commandheader.ctrl_head_bits.p = 0;
+	commandheader.ctrl_head_bits.p = get_parity(commandheader.ctrl_frame_head);
 
-    converted_commandheader = sys_cpu_to_be32(commandheader.ctrl_frame_head);
-    memcpy(txbuffer, &converted_commandheader, HEADER_SIZE);
+	converted_commandheader = sys_cpu_to_be32(commandheader.ctrl_frame_head);
+	memcpy(txbuffer, &converted_commandheader, HEADER_SIZE);
 
-    numberof_registerstosend = commandheader.ctrl_head_bits.len + 1;
-    for (uint8_t controlRegIndex = 0; controlRegIndex < numberof_registerstosend; controlRegIndex++) {
-        uint32_t data = sys_cpu_to_be32(p_regData->databuffer[controlRegIndex]);
-        memcpy(&txbuffer[HEADER_SIZE + controlRegIndex * REG_SIZE], &data, sizeof(uint32_t));
-    }
+	numberof_registerstosend = commandheader.ctrl_head_bits.len + 1;
+	for (uint8_t controlRegIndex = 0; controlRegIndex < numberof_registerstosend;
+	     controlRegIndex++) {
+		uint32_t data = sys_cpu_to_be32(p_regData->databuffer[controlRegIndex]);
+		memcpy(&txbuffer[HEADER_SIZE + controlRegIndex * REG_SIZE], &data,
+		       sizeof(uint32_t));
+	}
 
-    numberof_bytestosend =
-        HEADER_SIZE + ((commandheader.ctrl_head_bits.len + 1) * REG_SIZE) +
-        ignored_echoedbytes; // Added extra 4 bytes because last 4 bytes of payload will be ignored by MACPHY
+	numberof_bytestosend = HEADER_SIZE + ((commandheader.ctrl_head_bits.len + 1) * REG_SIZE) +
+			       ignored_echoedbytes; // Added extra 4 bytes because last 4 bytes of
+						    // payload will be ignored by MACPHY
 
-    transceive(txbuffer, rxbuffer, numberof_bytestosend);
+	transceive(txbuffer, rxbuffer, numberof_bytestosend);
 
-    memcpy((uint8_t*)&commandheader_echoed.ctrl_frame_head, &rxbuffer[ignored_echoedbytes], HEADER_SIZE);
-    commandheader_echoed.ctrl_frame_head = sys_be32_to_cpu(commandheader_echoed.ctrl_frame_head);
-    // TODO: check this logic and modify it if needed
-    if (commandheader.ctrl_head_bits.mms == 0) {
-        struct ctrl_cmd_reg readreg_infoinput;
-        struct ctrl_cmd_reg readreg_data;
+	memcpy((uint8_t *)&commandheader_echoed.ctrl_frame_head, &rxbuffer[ignored_echoedbytes],
+	       HEADER_SIZE);
+	commandheader_echoed.ctrl_frame_head =
+		sys_be32_to_cpu(commandheader_echoed.ctrl_frame_head);
+	// TODO: check this logic and modify it if needed
+	if (commandheader.ctrl_head_bits.mms == 0) {
+		struct ctrl_cmd_reg readreg_infoinput;
+		struct ctrl_cmd_reg readreg_data;
 
-        // Reads CONFIG0 register from MMS 0
-        readreg_infoinput.memorymap = MMS0;
-        readreg_infoinput.length = 0;
-        readreg_infoinput.address = OA_CONFIG0;
-        memset(&readreg_infoinput.databuffer[0], 0, MAX_REG_DATA_ONECHUNK);
+		// Reads CONFIG0 register from MMS 0
+		readreg_infoinput.memorymap = MMS0;
+		readreg_infoinput.length = 0;
+		readreg_infoinput.address = OA_CONFIG0;
+		memset(&readreg_infoinput.databuffer[0], 0, MAX_REG_DATA_ONECHUNK);
 
-        execution_status = t1s_hw_readreg(spi_dev, &readreg_infoinput, &readreg_data);
-        if (execution_status == false) {
-            printk("Reading CONFIG0 reg failed after writing (inside WriteReg)\n");
-        } else {
-            printk("CONFIG0 reg value is 0x%08x in WriteReg function\n", readreg_data.databuffer[0]);
-        }
-    }
+		execution_status = t1s_hw_readreg(spi_dev, &readreg_infoinput, &readreg_data);
+		if (execution_status == false) {
+			printk("Reading CONFIG0 reg failed after writing (inside WriteReg)\n");
+		} else {
+			printk("CONFIG0 reg value is 0x%08x in WriteReg function\n",
+			       readreg_data.databuffer[0]);
+		}
+	}
 
-    return writestatus;
+	return writestatus;
 }
 
-uint32_t write_register(const struct spi_dt_spec* spi_dev, uint8_t mms, uint16_t address, uint32_t data) {
-    struct ctrl_cmd_reg writereg_input;
-    bool execution_status = false;
-    writereg_input.memorymap = mms;
-    writereg_input.length = 0;
-    writereg_input.address = address;
-    writereg_input.databuffer[0] = data;
+uint32_t write_register(const struct spi_dt_spec *spi_dev, uint8_t mms, uint16_t address,
+			uint32_t data)
+{
+	struct ctrl_cmd_reg writereg_input;
+	bool execution_status = false;
+	writereg_input.memorymap = mms;
+	writereg_input.length = 0;
+	writereg_input.address = address;
+	writereg_input.databuffer[0] = data;
 
-    execution_status = t1s_hw_writereg(spi_dev, &writereg_input);
-    if (execution_status == true) {
-        return writereg_input.databuffer[0];
-    } else {
-        printk("ERROR: Register Write failed at MMS %d, Address %4x\n", mms, address);
-        return 0;
-    }
+	execution_status = t1s_hw_writereg(spi_dev, &writereg_input);
+	if (execution_status == true) {
+		return writereg_input.databuffer[0];
+	} else {
+		printk("ERROR: Register Write failed at MMS %d, Address %4x\n", mms, address);
+		return 0;
+	}
 }
 
-uint32_t read_register(const struct spi_dt_spec* spi_dev, uint8_t mms, uint16_t address) {
-    bool execution_status = false;
-    struct ctrl_cmd_reg readreg_infoinput;
-    struct ctrl_cmd_reg readreg_data;
-    readreg_infoinput.memorymap = mms;
-    readreg_infoinput.length = 0;
-    readreg_infoinput.address = address;
+uint32_t read_register(const struct spi_dt_spec *spi_dev, uint8_t mms, uint16_t address)
+{
+	bool execution_status = false;
+	struct ctrl_cmd_reg readreg_infoinput;
+	struct ctrl_cmd_reg readreg_data;
+	readreg_infoinput.memorymap = mms;
+	readreg_infoinput.length = 0;
+	readreg_infoinput.address = address;
 
-    execution_status = t1s_hw_readreg(spi_dev, &readreg_infoinput, &readreg_data);
-    if (execution_status == true) {
-        return readreg_data.databuffer[0];
-    } else {
-        printk("ERROR: Register Read failed at MMS %d, Address %4x\n", mms, address);
-        return 0;
-    }
+	execution_status = t1s_hw_readreg(spi_dev, &readreg_infoinput, &readreg_data);
+	if (execution_status == true) {
+		return readreg_data.databuffer[0];
+	} else {
+		printk("ERROR: Register Read failed at MMS %d, Address %4x\n", mms, address);
+		return 0;
+	}
 }
 
-static void set_macphy_register(const struct spi_dt_spec* spi_dev) {
-    uint8_t value1 = read_register(spi_dev, 0x04, 0x1F);
-    int8_t offset1;
-    if ((value1 & 0x10) != 0) {
-        offset1 = (int8_t)((uint8_t)value1 - 0x20);
-    } else {
-        offset1 = (int8_t)value1;
-    }
+static void set_macphy_register(const struct spi_dt_spec *spi_dev)
+{
+	uint8_t value1 = read_register(spi_dev, 0x04, 0x1F);
+	int8_t offset1;
+	if ((value1 & 0x10) != 0) {
+		offset1 = (int8_t)((uint8_t)value1 - 0x20);
+	} else {
+		offset1 = (int8_t)value1;
+	}
 
-    uint8_t value2 = read_register(spi_dev, 0x08, 0x1F);
-    int8_t offset2;
-    if ((value2 & 0x10) != 0) {
-        offset2 = (int8_t)((uint8_t)value2 - 0x20);
-    } else {
-        offset2 = (int8_t)value2;
-    }
+	uint8_t value2 = read_register(spi_dev, 0x08, 0x1F);
+	int8_t offset2;
+	if ((value2 & 0x10) != 0) {
+		offset2 = (int8_t)((uint8_t)value2 - 0x20);
+	} else {
+		offset2 = (int8_t)value2;
+	}
 
-    uint16_t cfgparam1 = (uint16_t)(((9 + offset1) & 0x3F) << 10) | (uint16_t)(((14 + offset1) & 0x3F) << 4) | 0x03;
-    uint16_t cfgparam2 = (uint16_t)(((40 + offset2) & 0x3F) << 10);
+	uint16_t cfgparam1 = (uint16_t)(((9 + offset1) & 0x3F) << 10) |
+			     (uint16_t)(((14 + offset1) & 0x3F) << 4) | 0x03;
+	uint16_t cfgparam2 = (uint16_t)(((40 + offset2) & 0x3F) << 10);
 
-    write_register(spi_dev, MMS4, 0x00D0, 0x3F31);
-    write_register(spi_dev, MMS4, 0x00E0, 0xC000);
-    write_register(spi_dev, MMS4, 0x0084, cfgparam1);
-    write_register(spi_dev, MMS4, 0x008A, cfgparam2);
-    write_register(spi_dev, MMS4, 0x00E9, 0x9E50);
-    write_register(spi_dev, MMS4, 0x00F5, 0x1CF8);
-    write_register(spi_dev, MMS4, 0x00F4, 0xC020);
-    write_register(spi_dev, MMS4, 0x00F8, 0xB900);
-    write_register(spi_dev, MMS4, 0x00F9, 0x4E53);
-    write_register(spi_dev, MMS4, 0x0081, 0x0080);
-    write_register(spi_dev, MMS4, 0x0091, 0x9660);
-    write_register(spi_dev, MMS4, 0x0077, 0x0028);
-    write_register(spi_dev, MMS4, 0x0043, 0x00FF);
-    write_register(spi_dev, MMS4, 0x0044, 0xFFFF);
-    write_register(spi_dev, MMS4, 0x0045, 0x0000);
-    write_register(spi_dev, MMS4, 0x0053, 0x00FF);
-    write_register(spi_dev, MMS4, 0x0054, 0xFFFF);
-    write_register(spi_dev, MMS4, 0x0055, 0x0000);
-    write_register(spi_dev, MMS4, 0x0040, 0x0002);
-    write_register(spi_dev, MMS4, 0x0050, 0x0002);
+	write_register(spi_dev, MMS4, 0x00D0, 0x3F31);
+	write_register(spi_dev, MMS4, 0x00E0, 0xC000);
+	write_register(spi_dev, MMS4, 0x0084, cfgparam1);
+	write_register(spi_dev, MMS4, 0x008A, cfgparam2);
+	write_register(spi_dev, MMS4, 0x00E9, 0x9E50);
+	write_register(spi_dev, MMS4, 0x00F5, 0x1CF8);
+	write_register(spi_dev, MMS4, 0x00F4, 0xC020);
+	write_register(spi_dev, MMS4, 0x00F8, 0xB900);
+	write_register(spi_dev, MMS4, 0x00F9, 0x4E53);
+	write_register(spi_dev, MMS4, 0x0081, 0x0080);
+	write_register(spi_dev, MMS4, 0x0091, 0x9660);
+	write_register(spi_dev, MMS4, 0x0077, 0x0028);
+	write_register(spi_dev, MMS4, 0x0043, 0x00FF);
+	write_register(spi_dev, MMS4, 0x0044, 0xFFFF);
+	write_register(spi_dev, MMS4, 0x0045, 0x0000);
+	write_register(spi_dev, MMS4, 0x0053, 0x00FF);
+	write_register(spi_dev, MMS4, 0x0054, 0xFFFF);
+	write_register(spi_dev, MMS4, 0x0055, 0x0000);
+	write_register(spi_dev, MMS4, 0x0040, 0x0002);
+	write_register(spi_dev, MMS4, 0x0050, 0x0002);
 }
 
-int set_register(const struct spi_dt_spec* spi_dev, int mode) {
-    uint32_t regval;
+int set_register(const struct spi_dt_spec *spi_dev, int mode)
+{
+	uint32_t regval;
 
-    /* Read OA_STATUS0 */
-    regval = read_register(spi_dev, MMS0, OA_STATUS0);
-    printk("OA_STATUS0: 0x%08x\n", regval);
+	/* Read OA_STATUS0 */
+	regval = read_register(spi_dev, MMS0, OA_STATUS0);
+	printk("OA_STATUS0: 0x%08x\n", regval);
 
-    /* Write 1 to RESETC bit of OA_STATUS0 */
-    regval |= (1 << 6);
-    write_register(spi_dev, MMS0, OA_STATUS0, regval);
-    printk("OA_STATUS0: 0x%08x\n", regval);
+	/* Write 1 to RESETC bit of OA_STATUS0 */
+	regval |= (1 << 6);
+	write_register(spi_dev, MMS0, OA_STATUS0, regval);
+	printk("OA_STATUS0: 0x%08x\n", regval);
 
-    regval = read_register(spi_dev, MMS4, CDCTL0);
-    write_register(spi_dev, MMS4, CDCTL0, regval | (1 << 15)); // Initial logic (disable collision detection)
-    printk("CDCTL0: 0x%08x\n", regval);
+	regval = read_register(spi_dev, MMS4, CDCTL0);
+	write_register(spi_dev, MMS4, CDCTL0,
+		       regval | (1 << 15)); // Initial logic (disable collision detection)
+	printk("CDCTL0: 0x%08x\n", regval);
 
-    // PLCA Configuration based on mode
-    // TODO: This process is temporary and assumes that there are only two nodes.
-    // TODO: Should be changed to get node info. from the command line.
-    if (mode == PLCA_MODE_COORDINATOR) {
-        write_register(spi_dev, MMS4, PLCA_CTRL1, 0x00000800); // Coordinator(node 0), 2 nodes
-        write_register(spi_dev, MMS1, MAC_SAB1, 0x11111111);   // Configure MAC Address (Temporary)
-        write_register(spi_dev, MMS1, MAC_SAT1, 0x00001111);   // Configure MAC Address (Temporary)
-        printk("PLCA_CTRL1: 0x%08x\n", read_register(spi_dev, MMS4, PLCA_CTRL1));
-        printk("MAC_SAB1: 0x%08x\n", read_register(spi_dev, MMS1, MAC_SAB1));
-        printk("MAC_SAT1: 0x%08x\n", read_register(spi_dev, MMS1, MAC_SAT1));
-    } else if (mode == PLCA_MODE_FOLLOWER) {
-        write_register(spi_dev, MMS4, PLCA_CTRL1, 0x00000801); // Follower, node 1
-        write_register(spi_dev, MMS1, MAC_SAB1, 0x22222222);   // Configure MAC Address (Temporary)
-        write_register(spi_dev, MMS1, MAC_SAT1, 0x00002222);   // Configure MAC Address (Temporary)
-        printk("PLCA_CTRL1: 0x%08x\n", read_register(spi_dev, MMS4, PLCA_CTRL1));
-        printk("MAC_SAB1: 0x%08x\n", read_register(spi_dev, MMS1, MAC_SAB1));
-        printk("MAC_SAT1: 0x%08x\n", read_register(spi_dev, MMS1, MAC_SAT1));
-    } else {
-        printk("Invalid mode: %d\n", mode);
-        return false;
-    }
-    set_macphy_register(spi_dev); // AN_LAN865x-Configuration
+	// PLCA Configuration based on mode
+	// TODO: This process is temporary and assumes that there are only two nodes.
+	// TODO: Should be changed to get node info. from the command line.
+	if (mode == PLCA_MODE_COORDINATOR) {
+		write_register(spi_dev, MMS4, PLCA_CTRL1,
+			       0x00000800); // Coordinator(node 0), 2 nodes
+		write_register(spi_dev, MMS1, MAC_SAB1,
+			       0x11111111); // Configure MAC Address (Temporary)
+		write_register(spi_dev, MMS1, MAC_SAT1,
+			       0x00001111); // Configure MAC Address (Temporary)
+		printk("PLCA_CTRL1: 0x%08x\n", read_register(spi_dev, MMS4, PLCA_CTRL1));
+		printk("MAC_SAB1: 0x%08x\n", read_register(spi_dev, MMS1, MAC_SAB1));
+		printk("MAC_SAT1: 0x%08x\n", read_register(spi_dev, MMS1, MAC_SAT1));
+	} else if (mode == PLCA_MODE_FOLLOWER) {
+		write_register(spi_dev, MMS4, PLCA_CTRL1, 0x00000801); // Follower, node 1
+		write_register(spi_dev, MMS1, MAC_SAB1,
+			       0x22222222); // Configure MAC Address (Temporary)
+		write_register(spi_dev, MMS1, MAC_SAT1,
+			       0x00002222); // Configure MAC Address (Temporary)
+		printk("PLCA_CTRL1: 0x%08x\n", read_register(spi_dev, MMS4, PLCA_CTRL1));
+		printk("MAC_SAB1: 0x%08x\n", read_register(spi_dev, MMS1, MAC_SAB1));
+		printk("MAC_SAT1: 0x%08x\n", read_register(spi_dev, MMS1, MAC_SAT1));
+	} else {
+		printk("Invalid mode: %d\n", mode);
+		return false;
+	}
+	set_macphy_register(spi_dev); // AN_LAN865x-Configuration
 
-    write_register(spi_dev, MMS4, PLCA_CTRL0, 0x00008000); // Enable PLCA
-    write_register(spi_dev, MMS1, MAC_NCFGR, 0x000000C0);  // Enable unicast, multicast
-    write_register(spi_dev, MMS1, MAC_NCR, 0x0000000C);    // Enable MACPHY TX, RX
-    printk("PLCA_CTRL0: 0x%08x\n", read_register(spi_dev, MMS4, PLCA_CTRL0));
-    printk("MAC_NCFGR: 0x%08x\n", read_register(spi_dev, MMS1, MAC_NCFGR));
-    printk("MAC_NCR: 0x%08x\n", read_register(spi_dev, MMS1, MAC_NCR));
+	write_register(spi_dev, MMS4, PLCA_CTRL0, 0x00008000); // Enable PLCA
+	write_register(spi_dev, MMS1, MAC_NCFGR, 0x000000C0);  // Enable unicast, multicast
+	write_register(spi_dev, MMS1, MAC_NCR, 0x0000000C);    // Enable MACPHY TX, RX
+	printk("PLCA_CTRL0: 0x%08x\n", read_register(spi_dev, MMS4, PLCA_CTRL0));
+	printk("MAC_NCFGR: 0x%08x\n", read_register(spi_dev, MMS1, MAC_NCFGR));
+	printk("MAC_NCR: 0x%08x\n", read_register(spi_dev, MMS1, MAC_NCR));
 
-    /* Read OA_CONFIG0 */
-    regval = read_register(spi_dev, MMS0, OA_CONFIG0);
-    printk("OA_CONFIG0: 0x%08x\n", regval);
+	/* Read OA_CONFIG0 */
+	regval = read_register(spi_dev, MMS0, OA_CONFIG0);
+	printk("OA_CONFIG0: 0x%08x\n", regval);
 
-    /* Set SYNC bit of OA_CONFIG0 */
-    regval |= (1 << 15);
-    regval &= ~(0x7);
-    regval |= (0x6);
-    write_register(spi_dev, MMS0, OA_CONFIG0, regval);
-    printk("OA_CONFIG0: 0x%08x\n", regval);
+	/* Set SYNC bit of OA_CONFIG0 */
+	regval |= (1 << 15);
+	regval &= ~(0x7);
+	regval |= (0x6);
+	write_register(spi_dev, MMS0, OA_CONFIG0, regval);
+	printk("OA_CONFIG0: 0x%08x\n", regval);
 
-    /* Read OA_STATUS0 */
-    regval = read_register(spi_dev, MMS0, OA_STATUS0);
-    printk("OA_STATUS0: 0x%08x\n", regval);
+	/* Read OA_STATUS0 */
+	regval = read_register(spi_dev, MMS0, OA_STATUS0);
+	printk("OA_STATUS0: 0x%08x\n", regval);
 
-    /* Clear RESETC bit of OA_STATUS0 */
-    regval &= ~(1UL << 6);
-    write_register(spi_dev, MMS0, OA_STATUS0, regval);
-    printk("OA_STATUS0: 0x%08x\n", regval);
+	/* Clear RESETC bit of OA_STATUS0 */
+	regval &= ~(1UL << 6);
+	write_register(spi_dev, MMS0, OA_STATUS0, regval);
+	printk("OA_STATUS0: 0x%08x\n", regval);
 
-    return true;
+	return true;
 }
 
-int send_packet(const struct spi_dt_spec* spi_dev, const uint8_t* data, uint16_t length) {
-    if (length > MAX_PACKET_SIZE) {
-        printk("Packet size is too large: %d\n", length);
-        return -1;
-    }
+int send_packet(const struct spi_dt_spec *spi_dev, const uint8_t *data, uint16_t length)
+{
+	if (length > MAX_PACKET_SIZE) {
+		printk("Packet size is too large: %d\n", length);
+		return -1;
+	}
 
-    uint8_t tx_buffer[HEADER_SIZE + MAX_PAYLOAD_BYTE] = {0};
-    uint8_t rx_buffer[MAX_PAYLOAD_BYTE + FOOTER_SIZE] = {0};
+	uint8_t tx_buffer[HEADER_SIZE + MAX_PAYLOAD_BYTE] = {0};
+	uint8_t rx_buffer[MAX_PAYLOAD_BYTE + FOOTER_SIZE] = {0};
 
-    union data_header data_header;
-    uint32_t be_header;
+	union data_header data_header;
+	uint32_t be_header;
 
-    uint32_t chunk_count = length / MAX_PAYLOAD_BYTE;
-    if (length % 64) {
-        chunk_count++;
-    }
+	uint32_t chunk_count = length / MAX_PAYLOAD_BYTE;
+	if (length % 64) {
+		chunk_count++;
+	}
 
-    uint32_t chunk_size = MAX_PAYLOAD_BYTE;
+	uint32_t chunk_size = MAX_PAYLOAD_BYTE;
 
-    data_header.tx_header_bits.dnc = DNC_COMMANDTYPE_DATA;
-    data_header.tx_header_bits.norx = NORX_NO_RECEIVE;
-    data_header.tx_header_bits.dv = DV_DATA_VALID;
-    for (uint32_t i = 0; i < chunk_count; i++) {
-        data_header.tx_header_bits.sv = SV_START_INVALID;
-        data_header.tx_header_bits.ev = EV_END_INVALID;
-        data_header.tx_header_bits.ebo = 0;
+	data_header.tx_header_bits.dnc = DNC_COMMANDTYPE_DATA;
+	data_header.tx_header_bits.norx = NORX_NO_RECEIVE;
+	data_header.tx_header_bits.dv = DV_DATA_VALID;
+	for (uint32_t i = 0; i < chunk_count; i++) {
+		data_header.tx_header_bits.sv = SV_START_INVALID;
+		data_header.tx_header_bits.ev = EV_END_INVALID;
+		data_header.tx_header_bits.ebo = 0;
 
-        if (i == 0) {  // First chunk
-            data_header.tx_header_bits.sv = SV_START_VALID;
-        } if (i == chunk_count - 1) {
-            chunk_size = length % MAX_PAYLOAD_BYTE;
-            if (chunk_size == 0) chunk_size = MAX_PAYLOAD_BYTE;
-            data_header.tx_header_bits.ev = EV_END_VALID;
-            data_header.tx_header_bits.ebo = chunk_size - 1;
-        }
+		if (i == 0) { // First chunk
+			data_header.tx_header_bits.sv = SV_START_VALID;
+		}
+		if (i == chunk_count - 1) {
+			chunk_size = length % MAX_PAYLOAD_BYTE;
+			if (chunk_size == 0) {
+				chunk_size = MAX_PAYLOAD_BYTE;
+			}
+			data_header.tx_header_bits.ev = EV_END_VALID;
+			data_header.tx_header_bits.ebo = chunk_size - 1;
+		}
 
-        data_header.tx_header_bits.p = 0;
-        data_header.tx_header_bits.p = get_parity(data_header.data_frame_head);
+		data_header.tx_header_bits.p = 0;
+		data_header.tx_header_bits.p = get_parity(data_header.data_frame_head);
 
-        be_header = sys_cpu_to_be32(data_header.data_frame_head);
-        memcpy(tx_buffer, &be_header, HEADER_SIZE);
-        memcpy(tx_buffer + HEADER_SIZE, data + i * MAX_PAYLOAD_BYTE, MAX_PAYLOAD_BYTE);
+		be_header = sys_cpu_to_be32(data_header.data_frame_head);
+		memcpy(tx_buffer, &be_header, HEADER_SIZE);
+		memcpy(tx_buffer + HEADER_SIZE, data + i * MAX_PAYLOAD_BYTE, MAX_PAYLOAD_BYTE);
 
-        struct spi_buf tx_buf = {.buf = tx_buffer, .len = HEADER_SIZE + MAX_PAYLOAD_BYTE};
-        const struct spi_buf_set tx_buf_set = {.buffers = &tx_buf, .count = 1};
-        struct spi_buf rx_buf = {.buf = rx_buffer, .len = MAX_PAYLOAD_BYTE + FOOTER_SIZE};
-        const struct spi_buf_set rx_buf_set = {.buffers = &rx_buf, .count = 1};
-        if (spi_transceive_dt(spi_dev, &tx_buf_set, &rx_buf_set) != 0) {
-            printk("SPI transceive failed while sending packet\n");
-            return -1;
-        }
-    }
+		struct spi_buf tx_buf = {.buf = tx_buffer, .len = HEADER_SIZE + MAX_PAYLOAD_BYTE};
+		const struct spi_buf_set tx_buf_set = {.buffers = &tx_buf, .count = 1};
+		struct spi_buf rx_buf = {.buf = rx_buffer, .len = MAX_PAYLOAD_BYTE + FOOTER_SIZE};
+		const struct spi_buf_set rx_buf_set = {.buffers = &rx_buf, .count = 1};
+		if (spi_transceive_dt(spi_dev, &tx_buf_set, &rx_buf_set) != 0) {
+			printk("SPI transceive failed while sending packet\n");
+			return -1;
+		}
+	}
 
-    return 0;
+	return 0;
 }
 
-int receive_packet(const struct spi_dt_spec* spi_dev, uint8_t* data, uint16_t* length) {
-    uint8_t tx_buffer[HEADER_SIZE + MAX_PAYLOAD_BYTE] = {0};
-    uint8_t rx_buffer[MAX_PAYLOAD_BYTE + FOOTER_SIZE] = {0};
+int receive_packet(const struct spi_dt_spec *spi_dev, uint8_t *data, uint16_t *length)
+{
+	uint8_t tx_buffer[HEADER_SIZE + MAX_PAYLOAD_BYTE] = {0};
+	uint8_t rx_buffer[MAX_PAYLOAD_BYTE + FOOTER_SIZE] = {0};
 
-    union data_header data_header;
-    union data_footer data_footer;
-    uint32_t be_header;
-    uint32_t be_footer;
-    size_t data_offset = 0;
-    size_t chunk_size = MAX_PAYLOAD_BYTE;
-    bool finished = false;
+	union data_header data_header;
+	union data_footer data_footer;
+	uint32_t be_header;
+	uint32_t be_footer;
+	size_t data_offset = 0;
+	size_t chunk_size = MAX_PAYLOAD_BYTE;
+	bool finished = false;
 
-    *length = 0;
-    
-    data_header.tx_header_bits.dnc = DNC_COMMANDTYPE_DATA;
-    data_header.tx_header_bits.norx = NORX_RECEIVE;
-    data_header.tx_header_bits.dv = DV_DATA_INVALID;
-    data_header.tx_header_bits.sv = SV_START_INVALID;
-    data_header.tx_header_bits.ev = EV_END_INVALID;
-    data_header.tx_header_bits.ebo = 0;
-    data_header.tx_header_bits.p = get_parity(data_header.data_frame_head);
-    while (*length < MAX_PACKET_SIZE && !finished) {
-        be_header = sys_cpu_to_be32(data_header.data_frame_head);
-        memcpy(tx_buffer, &be_header, HEADER_SIZE);
+	*length = 0;
 
-        struct spi_buf tx_buf = {.buf = tx_buffer, .len = HEADER_SIZE + MAX_PAYLOAD_BYTE};
-        const struct spi_buf_set tx_buf_set = {.buffers = &tx_buf, .count = 1};
-        struct spi_buf rx_buf = {.buf = rx_buffer, .len = MAX_PAYLOAD_BYTE + FOOTER_SIZE};
-        const struct spi_buf_set rx_buf_set = {.buffers = &rx_buf, .count = 1};
-        if (spi_transceive_dt(spi_dev, &tx_buf_set, &rx_buf_set) != 0) {
-            printk("SPI transceive failed while receiving packet\n");
-            return -1;
-        }
+	data_header.tx_header_bits.dnc = DNC_COMMANDTYPE_DATA;
+	data_header.tx_header_bits.norx = NORX_RECEIVE;
+	data_header.tx_header_bits.dv = DV_DATA_INVALID;
+	data_header.tx_header_bits.sv = SV_START_INVALID;
+	data_header.tx_header_bits.ev = EV_END_INVALID;
+	data_header.tx_header_bits.ebo = 0;
+	data_header.tx_header_bits.p = get_parity(data_header.data_frame_head);
+	while (*length < MAX_PACKET_SIZE && !finished) {
+		be_header = sys_cpu_to_be32(data_header.data_frame_head);
+		memcpy(tx_buffer, &be_header, HEADER_SIZE);
 
-        be_footer = *((uint32_t*)(rx_buffer + MAX_PAYLOAD_BYTE));
-        data_footer.data_frame_foot = sys_be32_to_cpu(be_footer);
+		struct spi_buf tx_buf = {.buf = tx_buffer, .len = HEADER_SIZE + MAX_PAYLOAD_BYTE};
+		const struct spi_buf_set tx_buf_set = {.buffers = &tx_buf, .count = 1};
+		struct spi_buf rx_buf = {.buf = rx_buffer, .len = MAX_PAYLOAD_BYTE + FOOTER_SIZE};
+		const struct spi_buf_set rx_buf_set = {.buffers = &rx_buf, .count = 1};
+		if (spi_transceive_dt(spi_dev, &tx_buf_set, &rx_buf_set) != 0) {
+			printk("SPI transceive failed while receiving packet\n");
+			return -1;
+		}
 
-        if (data_footer.rx_footer_bits.p != get_parity(data_footer.data_frame_foot)) {
-            printk("Parity error while receiving packet\n");
-            return -1;
-        }
+		be_footer = *((uint32_t *)(rx_buffer + MAX_PAYLOAD_BYTE));
+		data_footer.data_frame_foot = sys_be32_to_cpu(be_footer);
 
-        if (*length == 0) {  /* First chunk */
-            if (data_footer.rx_footer_bits.dv == DV_DATA_INVALID) {
-                /* No data to be received */
-                return 0;
-            }
+		if (data_footer.rx_footer_bits.p != get_parity(data_footer.data_frame_foot)) {
+			printk("Parity error while receiving packet\n");
+			return -1;
+		}
 
-            if (data_footer.rx_footer_bits.sv == SV_START_INVALID) {
-                printk("Invalid start of the packet\n");
-                return -1;
-            }
+		if (*length == 0) { /* First chunk */
+			if (data_footer.rx_footer_bits.dv == DV_DATA_INVALID) {
+				/* No data to be received */
+				return 0;
+			}
 
-            data_offset = (data_footer.rx_footer_bits.swo * 4);  /* 4 bytes per word */
-        }
-        
-        if (data_footer.rx_footer_bits.ev == EV_END_VALID) {  /* Last chunk */
-            chunk_size = data_footer.rx_footer_bits.ebo + 1;
-            finished = true;
-        }
+			if (data_footer.rx_footer_bits.sv == SV_START_INVALID) {
+				printk("Invalid start of the packet\n");
+				return -1;
+			}
 
-        memcpy(data + *length, rx_buffer + data_offset, chunk_size - data_offset);
-        *length += chunk_size - data_offset;
-        data_offset = 0;
-    }
+			data_offset = (data_footer.rx_footer_bits.swo * 4); /* 4 bytes per word */
+		}
 
-    return 0;
+		if (data_footer.rx_footer_bits.ev == EV_END_VALID) { /* Last chunk */
+			chunk_size = data_footer.rx_footer_bits.ebo + 1;
+			finished = true;
+		}
+
+		memcpy(data + *length, rx_buffer + data_offset, chunk_size - data_offset);
+		*length += chunk_size - data_offset;
+		data_offset = 0;
+	}
+
+	return 0;
 }

--- a/samples/t1s/src/lan8651.c
+++ b/samples/t1s/src/lan8651.c
@@ -59,7 +59,7 @@ static bool t1s_hw_readreg(const struct spi_dt_spec* spi_dev, struct ctrl_cmd_re
     {
         if (commandheader.ctrl_head_bits.len == 0) {
             memcpy((uint8_t*)&p_readRegData->databuffer[0], &(rxbuffer[ignored_echoedbytes + HEADER_SIZE]), REG_SIZE);
-            p_readRegData->databuffer[0] = sys_be32_to_cpu(p_readRegData->databuffer[1]);
+            p_readRegData->databuffer[0] = sys_be32_to_cpu(p_readRegData->databuffer[0]);
         } else {
             for (int regCount = 0; regCount <= commandheader.ctrl_head_bits.len; regCount++) {
                 memcpy((uint8_t*)&p_readRegData->databuffer[regCount],
@@ -83,7 +83,7 @@ static bool t1s_hw_writereg(const struct spi_dt_spec* spi_dev, struct ctrl_cmd_r
     bool execution_status = false;
     const uint8_t ignored_echoedbytes = HEADER_SIZE;
     uint8_t txbuffer[MAX_PAYLOAD_BYTE + HEADER_SIZE] = {0};
-    uint8_t rxbuffer[MAX_PAYLOAD_BYTE + HEADER_SIZE + 8] = {0};
+    uint8_t rxbuffer[MAX_PAYLOAD_BYTE + HEADER_SIZE] = {0};
     union ctrl_header commandheader;
     union ctrl_header commandheader_echoed;
     uint32_t converted_commandheader;
@@ -294,8 +294,8 @@ int send_packet(const struct spi_dt_spec* spi_dev, const uint8_t* data, uint16_t
         return -1;
     }
 
-    uint8_t tx_buffer[HEADER_SIZE + MAX_PAYLOAD_BYTE];
-    uint8_t rx_buffer[MAX_PAYLOAD_BYTE + FOOTER_SIZE];
+    uint8_t tx_buffer[HEADER_SIZE + MAX_PAYLOAD_BYTE] = {0};
+    uint8_t rx_buffer[MAX_PAYLOAD_BYTE + FOOTER_SIZE] = {0};
 
     union data_header data_header;
     uint32_t be_header;
@@ -345,8 +345,8 @@ int send_packet(const struct spi_dt_spec* spi_dev, const uint8_t* data, uint16_t
 }
 
 int receive_packet(const struct spi_dt_spec* spi_dev, uint8_t* data, uint16_t* length) {
-    uint8_t tx_buffer[HEADER_SIZE + MAX_PAYLOAD_BYTE];
-    uint8_t rx_buffer[MAX_PAYLOAD_BYTE + FOOTER_SIZE];
+    uint8_t tx_buffer[HEADER_SIZE + MAX_PAYLOAD_BYTE] = {0};
+    uint8_t rx_buffer[MAX_PAYLOAD_BYTE + FOOTER_SIZE] = {0};
 
     union data_header data_header;
     union data_footer data_footer;

--- a/samples/t1s/src/lan8651.h
+++ b/samples/t1s/src/lan8651.h
@@ -1,0 +1,370 @@
+#include <stdint.h>
+
+#include <zephyr/kernel.h>
+#include <zephyr/drivers/spi.h>
+
+#define MAX_CONTROL_CMD_LEN (0x7F)
+#define MAX_PAYLOAD_BYTE (64)
+#define REG_SIZE (4)
+#define MAX_REG_DATA_ONECONTROLCMD (MAX_CONTROL_CMD_LEN * REG_SIZE)
+#define MAX_REG_DATA_ONECHUNK (MAX_PAYLOAD_BYTE / REG_SIZE)
+#define MAX_DATA_DWORD_ONECHUNK (MAX_REG_DATA_ONECHUNK)
+#define HEADER_SIZE (4)
+#define FOOTER_SIZE (4)
+#define MAX_ENTRIES (100)
+#define MAX_PACKET_SIZE (1500)
+
+enum {
+    ARP_E_SUCCESS = 0,
+    ARP_E_REQUEST_FAILED,
+    ARP_E_REPLY_FAILED,
+    ARP_E_UNKNOWN_ERROR,
+};
+
+enum {
+    SPI_E_SUCCESS = 0,
+    SPI_E_UNKNOWN_ERROR,
+    SPI_E_INIT_ERROR,
+    SPI_E_ISR_INIT_ERROR,
+};
+
+enum {
+    PLCA_MODE_COORDINATOR = 0,
+    PLCA_MODE_FOLLOWER,
+    PLCA_MODE_INVALID,
+};
+
+enum {
+    MMS0 = 0x00,  /* Open Alliance 10BASE-T1x MAC-PHY Standard Registers */
+    MMS1 = 0x01,  /* MAC Registers */
+    MMS2 = 0x02,  /* PHY PCS Registers */
+    MMS3 = 0x03,  /* PHY PMA/PMD Registers */
+    MMS4 = 0x04,  /* PHY Vendor Specific Registers */
+    MMS10 = 0x0A, /* Miscellaneous Register Descriptions */
+};
+
+/* MMS0, Open Alliance 10BASE-T1x MAC-PHY Standard Registers */
+enum {
+    OA_ID = 0x00,
+    OA_PHYID = 0x01,
+    OA_STDCAP = 0x02,
+    OA_RESET = 0x03,
+    OA_CONFIG0 = 0x04,
+    OA_STATUS0 = 0x08,
+    OA_STATUS1 = 0x09,
+    OA_BUFSTS = 0X0B,
+    OA_IMASK0 = 0x0C,
+    OA_IMASK1 = 0x0D,
+    TTSCAH = 0x10,
+    TTSCAL = 0x11,
+    TTSCBH = 0x12,
+    TTSCBL = 0x13,
+    TTSCCH = 0x14,
+    TTSCCL = 0x15,
+    BASIC_CONTROL = 0xFF00,
+    BASIC_STATUS = 0xFF01,
+    PHY_ID1 = 0xFF02,
+    PHY_ID2 = 0xFF03,
+    MMDCTRL = 0xFF0D,
+    MMDAD = 0xFF0E
+};
+
+/* MMS1, MAC Registers */
+enum {
+    MAC_NCR = 0x00,
+    MAC_NCFGR = 0x01,
+    MAC_HRB = 0x20,
+    MAC_HRT = 0x21,
+    MAC_SAB1 = 0x22,
+    MAC_SAT1 = 0x23,
+    MAC_SAB2 = 0x24,
+    MAC_SAT2 = 0x25,
+    MAC_SAB3 = 0x26,
+    MAC_SAT3 = 0x27,
+    MAC_SAB4 = 0x28,
+    MAC_SAT4 = 0x29,
+    MAC_TIDM1 = 0x2A,
+    MAC_TIDM2 = 0x2B,
+    MAC_TIDM3 = 0x2C,
+    MAC_TIDM4 = 0x2D,
+    MAC_SAMB1 = 0x32,
+    MAC_SAMT1 = 0x33,
+    MAC_TISUBN = 0x6F,
+    MAC_TSH = 0x70,
+    MAC_TSL = 0x74,
+    MAC_TN = 0x75,
+    MAC_TA = 0x76,
+    MAC_TI = 0x77,
+    BMGR_CTL = 0x0200,
+    STATS0 = 0x0208,
+    STATS1 = 0x0209,
+    STATS2 = 0x020A,
+    STATS3 = 0x020B,
+    STATS4 = 0x020C,
+    STATS5 = 0x020D,
+    STATS6 = 0x020E,
+    STATS7 = 0x020F,
+    STATS8 = 0x0210,
+    STATS9 = 0x0211,
+    STATS10 = 0x0212,
+    STATS11 = 0x0213,
+    STATS12 = 0x0214
+};
+
+/* MMS2, PHY PCS Registers */
+enum { T1SPCSCTL = 0x08F3, T1SPCSSTS = 0x08F4, T1SPCSDIAG1 = 0x08F5, T1SPCSDIAG2 = 0x08F6 };
+
+/* MMS3, PHY PMA/PMD Registers */
+enum { T1PMAPMDEXTA = 0x12, T1PMAPMDCTL = 0x0834, T1SPMACTL = 0x08F9, T1SPMASTS = 0x08FA, T1STSTCTL = 0x08FB };
+
+/* MMS4, PHY Vendor Specific Registers */
+enum {
+    CTRL1 = 0x10,
+    STS1 = 0x18,
+    STS2 = 0x19,
+    STS3 = 0x1A,
+    IMSK1 = 0x1C,
+    IMSK2 = 0x1D,
+    CTRCTRL = 0x20,
+    TOCNTH = 0x24,
+    TOCNTL = 0x25,
+    BCNCNTH = 0x26,
+    BCNCNTL = 0x27,
+    MULTID0 = 0x30,
+    MULTID1 = 0x31,
+    MULTID2 = 0x32,
+    MULTID3 = 0x33,
+    PRSSTS = 0x36,
+    PRTMGMT2 = 0x3D,
+    IWDTOH = 0x3E,
+    IWDTOL = 0x3F,
+    TXMCTL = 0x40,
+    TXMPATH = 0x41,
+    TXMPATL = 0x42,
+    TXMMSKH = 0x43,
+    TXMMSKL = 0x44,
+    TXMLOC = 0x45,
+    TXMDLY = 0x49,
+    RXMCTL = 0x50,
+    RXMPATH = 0x51,
+    RXMPATL = 0x52,
+    RXMMSKH = 0x53,
+    RXMMSKL = 0x54,
+    RXMLOC = 0x55,
+    RXMDLY = 0x59,
+    CBSSPTHH = 0x60,
+    CBSSPTHL = 0x61,
+    CBSSTTHH = 0x62,
+    CBSSTTHL = 0x63,
+    CBSSLPCTL = 0x64,
+    CBSTPLMTH = 0x65,
+    CBSTPLMTL = 0x66,
+    CBSBTLMTH = 0x67,
+    CBSBTLMTL = 0x68,
+    CBSCRCTRH = 0x69,
+    CBSCRCTRL = 0x6A,
+    CBSCTRL = 0x6B,
+    PLCASKPCTL = 0x70,
+    PLCATOSKP = 0x71,
+    ACMACTL = 0x74,
+    SLPCTL0 = 0x80,
+    SLPCTL1 = 0x81,
+    CDCTL0 = 0x87,
+    SQICTL = 0xA0,
+    SQISTS0 = 0xA1,
+    SQICFG0 = 0xAA,
+    SQICFG2 = 0xAC,
+    ANALOG5 = 0xD5,
+    MIDVER = 0xCA00,
+    PLCA_CTRL0 = 0xCA01,
+    PLCA_CTRL1 = 0xCA02,
+    PLCA_STS = 0xCA03,
+    PLCA_TOTMR = 0xCA04,
+    PLCA_BURST = 0xCA05
+};
+
+/* MMS10, Miscellaneous Register Descriptions */
+enum {
+    QTXCFG = 0x81,
+    QRXCFG = 0x82,
+    PADCTRL = 0x88,
+    CLKOCTL = 0x89,
+    MISC = 0x8C,
+    DEVID = 0x94,
+    BUSPCS = 0x96,
+    CFGPRTCTL = 0x99,
+    ECCCTRL = 0x0100,
+    ECCSTS = 0x0101,
+    ECCFLTCTRL = 0x0102,
+    EC0CTRL = 0x0200,
+    EC1CTRL = 0x0201,
+    EC2CTRL = 0x0202,
+    EC3CTRL = 0x0203,
+    ECRDSTS = 0x0204,
+    ECTOT = 0x0205,
+    ECCLKSH = 0x0206,
+    ECCLKSL = 0x0207,
+    ECCLKNS = 0x0208,
+    ECRDTS0 = 0x0209,
+    ECRDTS1 = 0x020A,
+    ECRDTS2 = 0x020B,
+    ECRDTS3 = 0x020C,
+    ECRDTS4 = 0x020D,
+    ECRDTS5 = 0x020E,
+    ECRDTS6 = 0x020F,
+    ECRDTS7 = 0x0210,
+    ECRDTS8 = 0x0211,
+    ECRDTS9 = 0x0212,
+    ECRDTS10 = 0x0213,
+    ECRDTS11 = 0x0214,
+    ECRDTS12 = 0x0215,
+    ECRDTS13 = 0x0216,
+    ECRDTS14 = 0x0217,
+    ECRDTS15 = 0x0218,
+    PACYC = 0x021F,
+    PACTRL = 0x0220,
+    EG0STNS = 0x0221,
+    EG0STSECL = 0x0222,
+    EG0STSECH = 0x0223,
+    EG0PW = 0x0224,
+    EG0IT = 0x0225,
+    EG0CTL = 0x0226,
+    EG1STNS = 0x0227,
+    EG1STSECL = 0x0228,
+    EG1STSECH = 0x0229,
+    EG1PW = 0x022A,
+    EG1IT = 0x022B,
+    EG1CTL = 0x022C,
+    EG2STNS = 0x022D,
+    EG2STSECL = 0x022E,
+    EG2STSECH = 0x022F,
+    EG2PW = 0x0230,
+    EG2IT = 0x0231,
+    EG2CTL = 0x0232,
+    EG3STNS = 0x0233,
+    EG3STSECL = 0x0234,
+    EG3STSECH = 0x0235,
+    EG3PW = 0x0236,
+    EG3IT = 0x0237,
+    EG3CTL = 0x0238,
+    PPSCTL = 0X0239,
+    SEVINTEN = 0x023A,
+    SEVINTDIS = 0x023B,
+    SEVIM = 0x023C,
+    SEVSTS = 0x023D
+};
+
+struct reginfo {
+    char* desc;
+    int32_t address;
+};
+
+enum {
+    DNC_COMMANDTYPE_CONTROL = 0,
+    DNC_COMMANDTYPE_DATA = 1,
+    };
+
+enum {
+    REG_ADDR_INCREMENT_ENABLE = 0,
+    REG_ADDR_INCREMENT_DISABLE = 1,
+    };
+
+enum {
+    REG_COMMAND_TYPE_READ = 0,
+    REG_COMMAND_TYPE_WRITE
+    };
+
+enum {
+    NORX_NO_RECEIVE = 0,
+    NORX_RECEIVE = 1,
+};
+
+enum {
+    DV_DATA_INVALID = 0,
+    DV_DATA_VALID = 1,
+};
+
+enum {
+    SV_START_INVALID = 0,
+    SV_START_VALID = 1,
+};
+
+enum {
+    EV_END_INVALID = 0,
+    EV_END_VALID = 1,
+};
+
+enum {
+    HDRB_HEADER_OK = 0,
+    HDRB_HEADER_BAD = 1,
+};
+
+struct ctrl_cmd_reg {
+    uint8_t memorymap;
+    uint8_t length;
+    uint16_t address;
+    uint32_t databuffer[MAX_CONTROL_CMD_LEN];
+};
+
+union ctrl_header {
+    uint32_t ctrl_frame_head;
+    struct {
+        uint32_t p : 1;
+        uint32_t len : 7;
+        uint32_t addr : 16;
+        uint32_t mms : 4;
+        uint32_t aid : 1;
+        uint32_t wnr : 1;
+        uint32_t hdrb : 1;
+        uint32_t dnc : 1;
+    } ctrl_head_bits;
+};
+
+union data_header {
+    uint32_t data_frame_head;
+    struct {
+        uint32_t p : 1;
+        uint32_t rsvd3 : 5;
+        uint32_t tsc : 2;
+        uint32_t ebo : 6;
+        uint32_t ev : 1;
+        uint32_t rsvd2 : 1;
+        uint32_t swo : 4;
+        uint32_t sv : 1;
+        uint32_t dv : 1;
+        uint32_t vs : 2;
+        uint32_t rsvd1 : 5;
+        uint32_t norx : 1;
+        uint32_t seq : 1;
+        uint32_t dnc : 1;
+    } tx_header_bits;
+};
+
+union data_footer {
+    uint32_t data_frame_foot;
+    struct {
+        uint32_t p : 1;
+        uint32_t txc : 5;
+        uint32_t rtps : 1;
+        uint32_t rtsa : 1;
+        uint32_t ebo : 6;
+        uint32_t ev : 1;
+        uint32_t fd : 1;
+        uint32_t swo : 4;
+        uint32_t sv : 1;
+        uint32_t dv : 1;
+        uint32_t vs : 2;
+        uint32_t rba : 5;
+        uint32_t sync : 1;
+        uint32_t hdrb : 1;
+        uint32_t exst : 1;
+    } rx_footer_bits;
+};
+
+uint8_t get_parity(uint32_t valueToCalculateParity);
+uint32_t write_register(const struct spi_dt_spec* spi_dev, uint8_t mms, uint16_t address, uint32_t data);
+uint32_t read_register(const struct spi_dt_spec* spi_dev, uint8_t mms, uint16_t address);
+int set_register(const struct spi_dt_spec* spi_dev, int mode);
+
+int send_packet(const struct spi_dt_spec* spi_dev, const uint8_t* data, uint16_t length);
+int receive_packet(const struct spi_dt_spec* spi_dev, uint8_t* data, uint16_t* length);

--- a/samples/t1s/src/lan8651.h
+++ b/samples/t1s/src/lan8651.h
@@ -275,8 +275,8 @@ enum {
     };
 
 enum {
-    NORX_NO_RECEIVE = 0,
-    NORX_RECEIVE = 1,
+    NORX_RECEIVE = 0,
+    NORX_NO_RECEIVE = 1,
 };
 
 enum {

--- a/samples/t1s/src/lan8651.h
+++ b/samples/t1s/src/lan8651.h
@@ -3,368 +3,380 @@
 #include <zephyr/kernel.h>
 #include <zephyr/drivers/spi.h>
 
-#define MAX_CONTROL_CMD_LEN (0x7F)
-#define MAX_PAYLOAD_BYTE (64)
-#define REG_SIZE (4)
+#define MAX_CONTROL_CMD_LEN        (0x7F)
+#define MAX_PAYLOAD_BYTE           (64)
+#define REG_SIZE                   (4)
 #define MAX_REG_DATA_ONECONTROLCMD (MAX_CONTROL_CMD_LEN * REG_SIZE)
-#define MAX_REG_DATA_ONECHUNK (MAX_PAYLOAD_BYTE / REG_SIZE)
-#define MAX_DATA_DWORD_ONECHUNK (MAX_REG_DATA_ONECHUNK)
-#define HEADER_SIZE (4)
-#define FOOTER_SIZE (4)
-#define MAX_ENTRIES (100)
-#define MAX_PACKET_SIZE (1500)
+#define MAX_REG_DATA_ONECHUNK      (MAX_PAYLOAD_BYTE / REG_SIZE)
+#define MAX_DATA_DWORD_ONECHUNK    (MAX_REG_DATA_ONECHUNK)
+#define HEADER_SIZE                (4)
+#define FOOTER_SIZE                (4)
+#define MAX_ENTRIES                (100)
+#define MAX_PACKET_SIZE            (1500)
 
 enum {
-    ARP_E_SUCCESS = 0,
-    ARP_E_REQUEST_FAILED,
-    ARP_E_REPLY_FAILED,
-    ARP_E_UNKNOWN_ERROR,
+	ARP_E_SUCCESS = 0,
+	ARP_E_REQUEST_FAILED,
+	ARP_E_REPLY_FAILED,
+	ARP_E_UNKNOWN_ERROR,
 };
 
 enum {
-    SPI_E_SUCCESS = 0,
-    SPI_E_UNKNOWN_ERROR,
-    SPI_E_INIT_ERROR,
-    SPI_E_ISR_INIT_ERROR,
+	SPI_E_SUCCESS = 0,
+	SPI_E_UNKNOWN_ERROR,
+	SPI_E_INIT_ERROR,
+	SPI_E_ISR_INIT_ERROR,
 };
 
 enum {
-    PLCA_MODE_COORDINATOR = 0,
-    PLCA_MODE_FOLLOWER,
-    PLCA_MODE_INVALID,
+	PLCA_MODE_COORDINATOR = 0,
+	PLCA_MODE_FOLLOWER,
+	PLCA_MODE_INVALID,
 };
 
 enum {
-    MMS0 = 0x00,  /* Open Alliance 10BASE-T1x MAC-PHY Standard Registers */
-    MMS1 = 0x01,  /* MAC Registers */
-    MMS2 = 0x02,  /* PHY PCS Registers */
-    MMS3 = 0x03,  /* PHY PMA/PMD Registers */
-    MMS4 = 0x04,  /* PHY Vendor Specific Registers */
-    MMS10 = 0x0A, /* Miscellaneous Register Descriptions */
+	MMS0 = 0x00,  /* Open Alliance 10BASE-T1x MAC-PHY Standard Registers */
+	MMS1 = 0x01,  /* MAC Registers */
+	MMS2 = 0x02,  /* PHY PCS Registers */
+	MMS3 = 0x03,  /* PHY PMA/PMD Registers */
+	MMS4 = 0x04,  /* PHY Vendor Specific Registers */
+	MMS10 = 0x0A, /* Miscellaneous Register Descriptions */
 };
 
 /* MMS0, Open Alliance 10BASE-T1x MAC-PHY Standard Registers */
 enum {
-    OA_ID = 0x00,
-    OA_PHYID = 0x01,
-    OA_STDCAP = 0x02,
-    OA_RESET = 0x03,
-    OA_CONFIG0 = 0x04,
-    OA_STATUS0 = 0x08,
-    OA_STATUS1 = 0x09,
-    OA_BUFSTS = 0X0B,
-    OA_IMASK0 = 0x0C,
-    OA_IMASK1 = 0x0D,
-    TTSCAH = 0x10,
-    TTSCAL = 0x11,
-    TTSCBH = 0x12,
-    TTSCBL = 0x13,
-    TTSCCH = 0x14,
-    TTSCCL = 0x15,
-    BASIC_CONTROL = 0xFF00,
-    BASIC_STATUS = 0xFF01,
-    PHY_ID1 = 0xFF02,
-    PHY_ID2 = 0xFF03,
-    MMDCTRL = 0xFF0D,
-    MMDAD = 0xFF0E
+	OA_ID = 0x00,
+	OA_PHYID = 0x01,
+	OA_STDCAP = 0x02,
+	OA_RESET = 0x03,
+	OA_CONFIG0 = 0x04,
+	OA_STATUS0 = 0x08,
+	OA_STATUS1 = 0x09,
+	OA_BUFSTS = 0X0B,
+	OA_IMASK0 = 0x0C,
+	OA_IMASK1 = 0x0D,
+	TTSCAH = 0x10,
+	TTSCAL = 0x11,
+	TTSCBH = 0x12,
+	TTSCBL = 0x13,
+	TTSCCH = 0x14,
+	TTSCCL = 0x15,
+	BASIC_CONTROL = 0xFF00,
+	BASIC_STATUS = 0xFF01,
+	PHY_ID1 = 0xFF02,
+	PHY_ID2 = 0xFF03,
+	MMDCTRL = 0xFF0D,
+	MMDAD = 0xFF0E
 };
 
 /* MMS1, MAC Registers */
 enum {
-    MAC_NCR = 0x00,
-    MAC_NCFGR = 0x01,
-    MAC_HRB = 0x20,
-    MAC_HRT = 0x21,
-    MAC_SAB1 = 0x22,
-    MAC_SAT1 = 0x23,
-    MAC_SAB2 = 0x24,
-    MAC_SAT2 = 0x25,
-    MAC_SAB3 = 0x26,
-    MAC_SAT3 = 0x27,
-    MAC_SAB4 = 0x28,
-    MAC_SAT4 = 0x29,
-    MAC_TIDM1 = 0x2A,
-    MAC_TIDM2 = 0x2B,
-    MAC_TIDM3 = 0x2C,
-    MAC_TIDM4 = 0x2D,
-    MAC_SAMB1 = 0x32,
-    MAC_SAMT1 = 0x33,
-    MAC_TISUBN = 0x6F,
-    MAC_TSH = 0x70,
-    MAC_TSL = 0x74,
-    MAC_TN = 0x75,
-    MAC_TA = 0x76,
-    MAC_TI = 0x77,
-    BMGR_CTL = 0x0200,
-    STATS0 = 0x0208,
-    STATS1 = 0x0209,
-    STATS2 = 0x020A,
-    STATS3 = 0x020B,
-    STATS4 = 0x020C,
-    STATS5 = 0x020D,
-    STATS6 = 0x020E,
-    STATS7 = 0x020F,
-    STATS8 = 0x0210,
-    STATS9 = 0x0211,
-    STATS10 = 0x0212,
-    STATS11 = 0x0213,
-    STATS12 = 0x0214
+	MAC_NCR = 0x00,
+	MAC_NCFGR = 0x01,
+	MAC_HRB = 0x20,
+	MAC_HRT = 0x21,
+	MAC_SAB1 = 0x22,
+	MAC_SAT1 = 0x23,
+	MAC_SAB2 = 0x24,
+	MAC_SAT2 = 0x25,
+	MAC_SAB3 = 0x26,
+	MAC_SAT3 = 0x27,
+	MAC_SAB4 = 0x28,
+	MAC_SAT4 = 0x29,
+	MAC_TIDM1 = 0x2A,
+	MAC_TIDM2 = 0x2B,
+	MAC_TIDM3 = 0x2C,
+	MAC_TIDM4 = 0x2D,
+	MAC_SAMB1 = 0x32,
+	MAC_SAMT1 = 0x33,
+	MAC_TISUBN = 0x6F,
+	MAC_TSH = 0x70,
+	MAC_TSL = 0x74,
+	MAC_TN = 0x75,
+	MAC_TA = 0x76,
+	MAC_TI = 0x77,
+	BMGR_CTL = 0x0200,
+	STATS0 = 0x0208,
+	STATS1 = 0x0209,
+	STATS2 = 0x020A,
+	STATS3 = 0x020B,
+	STATS4 = 0x020C,
+	STATS5 = 0x020D,
+	STATS6 = 0x020E,
+	STATS7 = 0x020F,
+	STATS8 = 0x0210,
+	STATS9 = 0x0211,
+	STATS10 = 0x0212,
+	STATS11 = 0x0213,
+	STATS12 = 0x0214
 };
 
 /* MMS2, PHY PCS Registers */
-enum { T1SPCSCTL = 0x08F3, T1SPCSSTS = 0x08F4, T1SPCSDIAG1 = 0x08F5, T1SPCSDIAG2 = 0x08F6 };
+enum {
+	T1SPCSCTL = 0x08F3,
+	T1SPCSSTS = 0x08F4,
+	T1SPCSDIAG1 = 0x08F5,
+	T1SPCSDIAG2 = 0x08F6
+};
 
 /* MMS3, PHY PMA/PMD Registers */
-enum { T1PMAPMDEXTA = 0x12, T1PMAPMDCTL = 0x0834, T1SPMACTL = 0x08F9, T1SPMASTS = 0x08FA, T1STSTCTL = 0x08FB };
+enum {
+	T1PMAPMDEXTA = 0x12,
+	T1PMAPMDCTL = 0x0834,
+	T1SPMACTL = 0x08F9,
+	T1SPMASTS = 0x08FA,
+	T1STSTCTL = 0x08FB
+};
 
 /* MMS4, PHY Vendor Specific Registers */
 enum {
-    CTRL1 = 0x10,
-    STS1 = 0x18,
-    STS2 = 0x19,
-    STS3 = 0x1A,
-    IMSK1 = 0x1C,
-    IMSK2 = 0x1D,
-    CTRCTRL = 0x20,
-    TOCNTH = 0x24,
-    TOCNTL = 0x25,
-    BCNCNTH = 0x26,
-    BCNCNTL = 0x27,
-    MULTID0 = 0x30,
-    MULTID1 = 0x31,
-    MULTID2 = 0x32,
-    MULTID3 = 0x33,
-    PRSSTS = 0x36,
-    PRTMGMT2 = 0x3D,
-    IWDTOH = 0x3E,
-    IWDTOL = 0x3F,
-    TXMCTL = 0x40,
-    TXMPATH = 0x41,
-    TXMPATL = 0x42,
-    TXMMSKH = 0x43,
-    TXMMSKL = 0x44,
-    TXMLOC = 0x45,
-    TXMDLY = 0x49,
-    RXMCTL = 0x50,
-    RXMPATH = 0x51,
-    RXMPATL = 0x52,
-    RXMMSKH = 0x53,
-    RXMMSKL = 0x54,
-    RXMLOC = 0x55,
-    RXMDLY = 0x59,
-    CBSSPTHH = 0x60,
-    CBSSPTHL = 0x61,
-    CBSSTTHH = 0x62,
-    CBSSTTHL = 0x63,
-    CBSSLPCTL = 0x64,
-    CBSTPLMTH = 0x65,
-    CBSTPLMTL = 0x66,
-    CBSBTLMTH = 0x67,
-    CBSBTLMTL = 0x68,
-    CBSCRCTRH = 0x69,
-    CBSCRCTRL = 0x6A,
-    CBSCTRL = 0x6B,
-    PLCASKPCTL = 0x70,
-    PLCATOSKP = 0x71,
-    ACMACTL = 0x74,
-    SLPCTL0 = 0x80,
-    SLPCTL1 = 0x81,
-    CDCTL0 = 0x87,
-    SQICTL = 0xA0,
-    SQISTS0 = 0xA1,
-    SQICFG0 = 0xAA,
-    SQICFG2 = 0xAC,
-    ANALOG5 = 0xD5,
-    MIDVER = 0xCA00,
-    PLCA_CTRL0 = 0xCA01,
-    PLCA_CTRL1 = 0xCA02,
-    PLCA_STS = 0xCA03,
-    PLCA_TOTMR = 0xCA04,
-    PLCA_BURST = 0xCA05
+	CTRL1 = 0x10,
+	STS1 = 0x18,
+	STS2 = 0x19,
+	STS3 = 0x1A,
+	IMSK1 = 0x1C,
+	IMSK2 = 0x1D,
+	CTRCTRL = 0x20,
+	TOCNTH = 0x24,
+	TOCNTL = 0x25,
+	BCNCNTH = 0x26,
+	BCNCNTL = 0x27,
+	MULTID0 = 0x30,
+	MULTID1 = 0x31,
+	MULTID2 = 0x32,
+	MULTID3 = 0x33,
+	PRSSTS = 0x36,
+	PRTMGMT2 = 0x3D,
+	IWDTOH = 0x3E,
+	IWDTOL = 0x3F,
+	TXMCTL = 0x40,
+	TXMPATH = 0x41,
+	TXMPATL = 0x42,
+	TXMMSKH = 0x43,
+	TXMMSKL = 0x44,
+	TXMLOC = 0x45,
+	TXMDLY = 0x49,
+	RXMCTL = 0x50,
+	RXMPATH = 0x51,
+	RXMPATL = 0x52,
+	RXMMSKH = 0x53,
+	RXMMSKL = 0x54,
+	RXMLOC = 0x55,
+	RXMDLY = 0x59,
+	CBSSPTHH = 0x60,
+	CBSSPTHL = 0x61,
+	CBSSTTHH = 0x62,
+	CBSSTTHL = 0x63,
+	CBSSLPCTL = 0x64,
+	CBSTPLMTH = 0x65,
+	CBSTPLMTL = 0x66,
+	CBSBTLMTH = 0x67,
+	CBSBTLMTL = 0x68,
+	CBSCRCTRH = 0x69,
+	CBSCRCTRL = 0x6A,
+	CBSCTRL = 0x6B,
+	PLCASKPCTL = 0x70,
+	PLCATOSKP = 0x71,
+	ACMACTL = 0x74,
+	SLPCTL0 = 0x80,
+	SLPCTL1 = 0x81,
+	CDCTL0 = 0x87,
+	SQICTL = 0xA0,
+	SQISTS0 = 0xA1,
+	SQICFG0 = 0xAA,
+	SQICFG2 = 0xAC,
+	ANALOG5 = 0xD5,
+	MIDVER = 0xCA00,
+	PLCA_CTRL0 = 0xCA01,
+	PLCA_CTRL1 = 0xCA02,
+	PLCA_STS = 0xCA03,
+	PLCA_TOTMR = 0xCA04,
+	PLCA_BURST = 0xCA05
 };
 
 /* MMS10, Miscellaneous Register Descriptions */
 enum {
-    QTXCFG = 0x81,
-    QRXCFG = 0x82,
-    PADCTRL = 0x88,
-    CLKOCTL = 0x89,
-    MISC = 0x8C,
-    DEVID = 0x94,
-    BUSPCS = 0x96,
-    CFGPRTCTL = 0x99,
-    ECCCTRL = 0x0100,
-    ECCSTS = 0x0101,
-    ECCFLTCTRL = 0x0102,
-    EC0CTRL = 0x0200,
-    EC1CTRL = 0x0201,
-    EC2CTRL = 0x0202,
-    EC3CTRL = 0x0203,
-    ECRDSTS = 0x0204,
-    ECTOT = 0x0205,
-    ECCLKSH = 0x0206,
-    ECCLKSL = 0x0207,
-    ECCLKNS = 0x0208,
-    ECRDTS0 = 0x0209,
-    ECRDTS1 = 0x020A,
-    ECRDTS2 = 0x020B,
-    ECRDTS3 = 0x020C,
-    ECRDTS4 = 0x020D,
-    ECRDTS5 = 0x020E,
-    ECRDTS6 = 0x020F,
-    ECRDTS7 = 0x0210,
-    ECRDTS8 = 0x0211,
-    ECRDTS9 = 0x0212,
-    ECRDTS10 = 0x0213,
-    ECRDTS11 = 0x0214,
-    ECRDTS12 = 0x0215,
-    ECRDTS13 = 0x0216,
-    ECRDTS14 = 0x0217,
-    ECRDTS15 = 0x0218,
-    PACYC = 0x021F,
-    PACTRL = 0x0220,
-    EG0STNS = 0x0221,
-    EG0STSECL = 0x0222,
-    EG0STSECH = 0x0223,
-    EG0PW = 0x0224,
-    EG0IT = 0x0225,
-    EG0CTL = 0x0226,
-    EG1STNS = 0x0227,
-    EG1STSECL = 0x0228,
-    EG1STSECH = 0x0229,
-    EG1PW = 0x022A,
-    EG1IT = 0x022B,
-    EG1CTL = 0x022C,
-    EG2STNS = 0x022D,
-    EG2STSECL = 0x022E,
-    EG2STSECH = 0x022F,
-    EG2PW = 0x0230,
-    EG2IT = 0x0231,
-    EG2CTL = 0x0232,
-    EG3STNS = 0x0233,
-    EG3STSECL = 0x0234,
-    EG3STSECH = 0x0235,
-    EG3PW = 0x0236,
-    EG3IT = 0x0237,
-    EG3CTL = 0x0238,
-    PPSCTL = 0X0239,
-    SEVINTEN = 0x023A,
-    SEVINTDIS = 0x023B,
-    SEVIM = 0x023C,
-    SEVSTS = 0x023D
+	QTXCFG = 0x81,
+	QRXCFG = 0x82,
+	PADCTRL = 0x88,
+	CLKOCTL = 0x89,
+	MISC = 0x8C,
+	DEVID = 0x94,
+	BUSPCS = 0x96,
+	CFGPRTCTL = 0x99,
+	ECCCTRL = 0x0100,
+	ECCSTS = 0x0101,
+	ECCFLTCTRL = 0x0102,
+	EC0CTRL = 0x0200,
+	EC1CTRL = 0x0201,
+	EC2CTRL = 0x0202,
+	EC3CTRL = 0x0203,
+	ECRDSTS = 0x0204,
+	ECTOT = 0x0205,
+	ECCLKSH = 0x0206,
+	ECCLKSL = 0x0207,
+	ECCLKNS = 0x0208,
+	ECRDTS0 = 0x0209,
+	ECRDTS1 = 0x020A,
+	ECRDTS2 = 0x020B,
+	ECRDTS3 = 0x020C,
+	ECRDTS4 = 0x020D,
+	ECRDTS5 = 0x020E,
+	ECRDTS6 = 0x020F,
+	ECRDTS7 = 0x0210,
+	ECRDTS8 = 0x0211,
+	ECRDTS9 = 0x0212,
+	ECRDTS10 = 0x0213,
+	ECRDTS11 = 0x0214,
+	ECRDTS12 = 0x0215,
+	ECRDTS13 = 0x0216,
+	ECRDTS14 = 0x0217,
+	ECRDTS15 = 0x0218,
+	PACYC = 0x021F,
+	PACTRL = 0x0220,
+	EG0STNS = 0x0221,
+	EG0STSECL = 0x0222,
+	EG0STSECH = 0x0223,
+	EG0PW = 0x0224,
+	EG0IT = 0x0225,
+	EG0CTL = 0x0226,
+	EG1STNS = 0x0227,
+	EG1STSECL = 0x0228,
+	EG1STSECH = 0x0229,
+	EG1PW = 0x022A,
+	EG1IT = 0x022B,
+	EG1CTL = 0x022C,
+	EG2STNS = 0x022D,
+	EG2STSECL = 0x022E,
+	EG2STSECH = 0x022F,
+	EG2PW = 0x0230,
+	EG2IT = 0x0231,
+	EG2CTL = 0x0232,
+	EG3STNS = 0x0233,
+	EG3STSECL = 0x0234,
+	EG3STSECH = 0x0235,
+	EG3PW = 0x0236,
+	EG3IT = 0x0237,
+	EG3CTL = 0x0238,
+	PPSCTL = 0X0239,
+	SEVINTEN = 0x023A,
+	SEVINTDIS = 0x023B,
+	SEVIM = 0x023C,
+	SEVSTS = 0x023D
 };
 
 struct reginfo {
-    char* desc;
-    int32_t address;
+	char *desc;
+	int32_t address;
 };
 
 enum {
-    DNC_COMMANDTYPE_CONTROL = 0,
-    DNC_COMMANDTYPE_DATA = 1,
-    };
-
-enum {
-    REG_ADDR_INCREMENT_ENABLE = 0,
-    REG_ADDR_INCREMENT_DISABLE = 1,
-    };
-
-enum {
-    REG_COMMAND_TYPE_READ = 0,
-    REG_COMMAND_TYPE_WRITE
-    };
-
-enum {
-    NORX_RECEIVE = 0,
-    NORX_NO_RECEIVE = 1,
+	DNC_COMMANDTYPE_CONTROL = 0,
+	DNC_COMMANDTYPE_DATA = 1,
 };
 
 enum {
-    DV_DATA_INVALID = 0,
-    DV_DATA_VALID = 1,
+	REG_ADDR_INCREMENT_ENABLE = 0,
+	REG_ADDR_INCREMENT_DISABLE = 1,
 };
 
 enum {
-    SV_START_INVALID = 0,
-    SV_START_VALID = 1,
+	REG_COMMAND_TYPE_READ = 0,
+	REG_COMMAND_TYPE_WRITE
 };
 
 enum {
-    EV_END_INVALID = 0,
-    EV_END_VALID = 1,
+	NORX_RECEIVE = 0,
+	NORX_NO_RECEIVE = 1,
 };
 
 enum {
-    HDRB_HEADER_OK = 0,
-    HDRB_HEADER_BAD = 1,
+	DV_DATA_INVALID = 0,
+	DV_DATA_VALID = 1,
+};
+
+enum {
+	SV_START_INVALID = 0,
+	SV_START_VALID = 1,
+};
+
+enum {
+	EV_END_INVALID = 0,
+	EV_END_VALID = 1,
+};
+
+enum {
+	HDRB_HEADER_OK = 0,
+	HDRB_HEADER_BAD = 1,
 };
 
 struct ctrl_cmd_reg {
-    uint8_t memorymap;
-    uint8_t length;
-    uint16_t address;
-    uint32_t databuffer[MAX_CONTROL_CMD_LEN];
+	uint8_t memorymap;
+	uint8_t length;
+	uint16_t address;
+	uint32_t databuffer[MAX_CONTROL_CMD_LEN];
 };
 
 union ctrl_header {
-    uint32_t ctrl_frame_head;
-    struct {
-        uint32_t p : 1;
-        uint32_t len : 7;
-        uint32_t addr : 16;
-        uint32_t mms : 4;
-        uint32_t aid : 1;
-        uint32_t wnr : 1;
-        uint32_t hdrb : 1;
-        uint32_t dnc : 1;
-    } ctrl_head_bits;
+	uint32_t ctrl_frame_head;
+	struct {
+		uint32_t p: 1;
+		uint32_t len: 7;
+		uint32_t addr: 16;
+		uint32_t mms: 4;
+		uint32_t aid: 1;
+		uint32_t wnr: 1;
+		uint32_t hdrb: 1;
+		uint32_t dnc: 1;
+	} ctrl_head_bits;
 };
 
 union data_header {
-    uint32_t data_frame_head;
-    struct {
-        uint32_t p : 1;
-        uint32_t rsvd3 : 5;
-        uint32_t tsc : 2;
-        uint32_t ebo : 6;
-        uint32_t ev : 1;
-        uint32_t rsvd2 : 1;
-        uint32_t swo : 4;
-        uint32_t sv : 1;
-        uint32_t dv : 1;
-        uint32_t vs : 2;
-        uint32_t rsvd1 : 5;
-        uint32_t norx : 1;
-        uint32_t seq : 1;
-        uint32_t dnc : 1;
-    } tx_header_bits;
+	uint32_t data_frame_head;
+	struct {
+		uint32_t p: 1;
+		uint32_t rsvd3: 5;
+		uint32_t tsc: 2;
+		uint32_t ebo: 6;
+		uint32_t ev: 1;
+		uint32_t rsvd2: 1;
+		uint32_t swo: 4;
+		uint32_t sv: 1;
+		uint32_t dv: 1;
+		uint32_t vs: 2;
+		uint32_t rsvd1: 5;
+		uint32_t norx: 1;
+		uint32_t seq: 1;
+		uint32_t dnc: 1;
+	} tx_header_bits;
 };
 
 union data_footer {
-    uint32_t data_frame_foot;
-    struct {
-        uint32_t p : 1;
-        uint32_t txc : 5;
-        uint32_t rtps : 1;
-        uint32_t rtsa : 1;
-        uint32_t ebo : 6;
-        uint32_t ev : 1;
-        uint32_t fd : 1;
-        uint32_t swo : 4;
-        uint32_t sv : 1;
-        uint32_t dv : 1;
-        uint32_t vs : 2;
-        uint32_t rba : 5;
-        uint32_t sync : 1;
-        uint32_t hdrb : 1;
-        uint32_t exst : 1;
-    } rx_footer_bits;
+	uint32_t data_frame_foot;
+	struct {
+		uint32_t p: 1;
+		uint32_t txc: 5;
+		uint32_t rtps: 1;
+		uint32_t rtsa: 1;
+		uint32_t ebo: 6;
+		uint32_t ev: 1;
+		uint32_t fd: 1;
+		uint32_t swo: 4;
+		uint32_t sv: 1;
+		uint32_t dv: 1;
+		uint32_t vs: 2;
+		uint32_t rba: 5;
+		uint32_t sync: 1;
+		uint32_t hdrb: 1;
+		uint32_t exst: 1;
+	} rx_footer_bits;
 };
 
 uint8_t get_parity(uint32_t valueToCalculateParity);
-uint32_t write_register(const struct spi_dt_spec* spi_dev, uint8_t mms, uint16_t address, uint32_t data);
-uint32_t read_register(const struct spi_dt_spec* spi_dev, uint8_t mms, uint16_t address);
-int set_register(const struct spi_dt_spec* spi_dev, int mode);
+uint32_t write_register(const struct spi_dt_spec *spi_dev, uint8_t mms, uint16_t address,
+			uint32_t data);
+uint32_t read_register(const struct spi_dt_spec *spi_dev, uint8_t mms, uint16_t address);
+int set_register(const struct spi_dt_spec *spi_dev, int mode);
 
-int send_packet(const struct spi_dt_spec* spi_dev, const uint8_t* data, uint16_t length);
-int receive_packet(const struct spi_dt_spec* spi_dev, uint8_t* data, uint16_t* length);
+int send_packet(const struct spi_dt_spec *spi_dev, const uint8_t *data, uint16_t length);
+int receive_packet(const struct spi_dt_spec *spi_dev, uint8_t *data, uint16_t *length);

--- a/samples/t1s/src/main.c
+++ b/samples/t1s/src/main.c
@@ -5,7 +5,6 @@
 
 #include "lan8651.h"
 #include "arp.h"
-#include "spi.h"
 
 #define SPI_NODE DT_ALIAS(spi0)
 

--- a/samples/t1s/src/main.c
+++ b/samples/t1s/src/main.c
@@ -8,67 +8,82 @@
 #include "arp.h"
 #include "perf.h"
 
-#define THROUGHPUT_DURATION 10
-#define THROUGHPUT_WARMUP 0
+#define THROUGHPUT_DURATION     10
+#define THROUGHPUT_WARMUP       0
 #define THROUGHPUT_PAYLOAD_SIZE 1500
 
 #define SPI_NODE DT_ALIAS(spi0)
 
 struct spi_dt_spec spi_dev;
 
-const uint8_t my_mac_addr[ETH_ALEN] = {0x11, 0x11, 0x11, 0x11, 0x11, 0x11, };
+const uint8_t my_mac_addr[ETH_ALEN] = {
+	0x11, 0x11, 0x11, 0x11, 0x11, 0x11,
+};
 const uint8_t target_mac_addr[ETH_ALEN] = {0xd0, 0xd1, 0x95, 0x30, 0x23, 0x01};
-const uint8_t my_ip_addr[IP_LEN] = {10, 1, 1, 2, };
-const uint8_t target_ip_addr[IP_LEN] = {10, 1, 1, 1, };
+const uint8_t my_ip_addr[IP_LEN] = {
+	10,
+	1,
+	1,
+	2,
+};
+const uint8_t target_ip_addr[IP_LEN] = {
+	10,
+	1,
+	1,
+	1,
+};
 
-
-static void arp_test() {
-    send_arp_request(&spi_dev, my_mac_addr, my_ip_addr, target_ip_addr);
-    receive_arp_reply(&spi_dev);
+static void arp_test()
+{
+	send_arp_request(&spi_dev, my_mac_addr, my_ip_addr, target_ip_addr);
+	receive_arp_reply(&spi_dev);
 }
 
-static void throughput_test() {
-    uint8_t payload[MAX_PERF_PAYLOAD] = {0};
-    uint16_t len = 0;
-    send_perf_req_packet(&spi_dev, my_mac_addr, target_mac_addr, THROUGHPUT_DURATION, THROUGHPUT_WARMUP);
-    len = make_perf_data_packet(my_mac_addr, target_mac_addr, payload, THROUGHPUT_PAYLOAD_SIZE);
-    struct ethhdr* eth = (struct ethhdr*)payload;
-    struct perf_header* perf = (struct perf_header*)(eth + 1);
-    uint32_t i = 0;
-    while (true) {
-        perf->id = sys_cpu_to_be32(i);
-        send_perf_data_packet(&spi_dev, payload, len);
-        i++;
-    }
+static void throughput_test()
+{
+	uint8_t payload[MAX_PERF_PAYLOAD] = {0};
+	uint16_t len = 0;
+	send_perf_req_packet(&spi_dev, my_mac_addr, target_mac_addr, THROUGHPUT_DURATION,
+			     THROUGHPUT_WARMUP);
+	len = make_perf_data_packet(my_mac_addr, target_mac_addr, payload, THROUGHPUT_PAYLOAD_SIZE);
+	struct ethhdr *eth = (struct ethhdr *)payload;
+	struct perf_header *perf = (struct perf_header *)(eth + 1);
+	uint32_t i = 0;
+	while (true) {
+		perf->id = sys_cpu_to_be32(i);
+		send_perf_data_packet(&spi_dev, payload, len);
+		i++;
+	}
 }
 
-static void latency_test() {
-    uint32_t id = 0;
-    uint16_t len = 0;
-    uint8_t client_mac_addr[ETH_ALEN];
-    uint8_t payload[MAX_PERF_PAYLOAD] = {0};
+static void latency_test()
+{
+	uint32_t id = 0;
+	uint16_t len = 0;
+	uint8_t client_mac_addr[ETH_ALEN];
+	uint8_t payload[MAX_PERF_PAYLOAD] = {0};
 
-    while (true) {
-        while (id == 0) {
-            recv_latency_req(&spi_dev, client_mac_addr, &id);
-        }
-        len = make_latency_res(payload, my_mac_addr, client_mac_addr, id);
-        send_latency_res(&spi_dev, payload, len);
-        id = 0;
-    }
+	while (true) {
+		while (id == 0) {
+			recv_latency_req(&spi_dev, client_mac_addr, &id);
+		}
+		len = make_latency_res(payload, my_mac_addr, client_mac_addr, id);
+		send_latency_res(&spi_dev, payload, len);
+		id = 0;
+	}
 }
 
 int main(void)
 {
-    spi_dev.bus = DEVICE_DT_GET(SPI_NODE);
-    spi_dev.config.frequency = 25000000;
-    spi_dev.config.operation = SPI_OP_MODE_MASTER | SPI_WORD_SET(32) | SPI_HOLD_ON_CS;
+	spi_dev.bus = DEVICE_DT_GET(SPI_NODE);
+	spi_dev.config.frequency = 25000000;
+	spi_dev.config.operation = SPI_OP_MODE_MASTER | SPI_WORD_SET(32) | SPI_HOLD_ON_CS;
 
-    set_register(&spi_dev, PLCA_MODE_COORDINATOR);
+	set_register(&spi_dev, PLCA_MODE_COORDINATOR);
 
-    // arp_test();
-    // throughput_test();
-    latency_test();
+	// arp_test();
+	// throughput_test();
+	latency_test();
 
-    return 0;
+	return 0;
 }

--- a/samples/t1s/src/main.c
+++ b/samples/t1s/src/main.c
@@ -5,6 +5,7 @@
 
 #include "lan8651.h"
 #include "arp.h"
+#include "spi.h"
 
 #define SPI_NODE DT_ALIAS(spi0)
 

--- a/samples/t1s/src/main.c
+++ b/samples/t1s/src/main.c
@@ -1,0 +1,34 @@
+#include <stdint.h>
+
+#include <zephyr/drivers/spi.h>
+#include <zephyr/sys/printk.h>
+
+#include "lan8651.h"
+#include "arp.h"
+
+#define SPI_NODE DT_ALIAS(spi0)
+
+struct spi_dt_spec spi_dev;
+
+const uint8_t my_mac_addr[ETH_ALEN] = {0x11, 0x11, 0x11, 0x11, 0x11, 0x11, };
+const uint8_t my_ip_addr[IP_LEN] = {10, 1, 1, 2, };
+const uint8_t target_ip_addr[IP_LEN] = {10, 1, 1, 1, };
+
+
+void arp_test() {
+    send_arp_request(&spi_dev, my_mac_addr, my_ip_addr, target_ip_addr);
+    receive_arp_reply(&spi_dev);
+}
+
+int main(void)
+{
+    spi_dev.bus = DEVICE_DT_GET(SPI_NODE);
+    spi_dev.config.frequency = 25000000;
+    spi_dev.config.operation = SPI_OP_MODE_MASTER | SPI_WORD_SET(32) | SPI_HOLD_ON_CS;
+
+    set_register(&spi_dev, PLCA_MODE_COORDINATOR);
+
+    arp_test();
+
+    return 0;
+}

--- a/samples/t1s/src/main.c
+++ b/samples/t1s/src/main.c
@@ -3,21 +3,59 @@
 #include <zephyr/drivers/spi.h>
 #include <zephyr/sys/printk.h>
 
+#include "eth.h"
 #include "lan8651.h"
 #include "arp.h"
+#include "perf.h"
+
+#define THROUGHPUT_DURATION 10
+#define THROUGHPUT_WARMUP 0
+#define THROUGHPUT_PAYLOAD_SIZE 1500
 
 #define SPI_NODE DT_ALIAS(spi0)
 
 struct spi_dt_spec spi_dev;
 
 const uint8_t my_mac_addr[ETH_ALEN] = {0x11, 0x11, 0x11, 0x11, 0x11, 0x11, };
+const uint8_t target_mac_addr[ETH_ALEN] = {0xd0, 0xd1, 0x95, 0x30, 0x23, 0x01};
 const uint8_t my_ip_addr[IP_LEN] = {10, 1, 1, 2, };
 const uint8_t target_ip_addr[IP_LEN] = {10, 1, 1, 1, };
 
 
-void arp_test() {
+static void arp_test() {
     send_arp_request(&spi_dev, my_mac_addr, my_ip_addr, target_ip_addr);
     receive_arp_reply(&spi_dev);
+}
+
+static void throughput_test() {
+    uint8_t payload[MAX_PERF_PAYLOAD] = {0};
+    uint16_t len = 0;
+    send_perf_req_packet(&spi_dev, my_mac_addr, target_mac_addr, THROUGHPUT_DURATION, THROUGHPUT_WARMUP);
+    len = make_perf_data_packet(my_mac_addr, target_mac_addr, payload, THROUGHPUT_PAYLOAD_SIZE);
+    struct ethhdr* eth = (struct ethhdr*)payload;
+    struct perf_header* perf = (struct perf_header*)(eth + 1);
+    uint32_t i = 0;
+    while (true) {
+        perf->id = sys_cpu_to_be32(i);
+        send_perf_data_packet(&spi_dev, payload, len);
+        i++;
+    }
+}
+
+static void latency_test() {
+    uint32_t id = 0;
+    uint16_t len = 0;
+    uint8_t client_mac_addr[ETH_ALEN];
+    uint8_t payload[MAX_PERF_PAYLOAD] = {0};
+
+    while (true) {
+        while (id == 0) {
+            recv_latency_req(&spi_dev, client_mac_addr, &id);
+        }
+        len = make_latency_res(payload, my_mac_addr, client_mac_addr, id);
+        send_latency_res(&spi_dev, payload, len);
+        id = 0;
+    }
 }
 
 int main(void)
@@ -28,7 +66,9 @@ int main(void)
 
     set_register(&spi_dev, PLCA_MODE_COORDINATOR);
 
-    arp_test();
+    // arp_test();
+    // throughput_test();
+    latency_test();
 
     return 0;
 }

--- a/samples/t1s/src/perf.c
+++ b/samples/t1s/src/perf.c
@@ -168,14 +168,14 @@ int recv_latency_req(const struct spi_dt_spec *spi, uint8_t source_mac_addr[ETH_
 	const struct spi_buf_set rx_buf_set = {.buffers = &rx_buf, .count = 1};
 	spi_transceive_dt(spi, &tx_buf_set, &rx_buf_set);
 
-	union data_footer data_footer;
-	data_footer.data_frame_foot = sys_be32_to_cpu(*(uint32_t *)(rxbuffer + MAX_PAYLOAD_BYTE));
-	if (data_footer.rx_footer_bits.p != get_parity(data_footer.data_frame_foot)) {
+	union data_footer footer;
+	footer.data_frame_foot = sys_be32_to_cpu(*(uint32_t *)(rxbuffer + MAX_PAYLOAD_BYTE));
+	if (footer.rx_footer_bits.p != get_parity(footer.data_frame_foot)) {
 		printk("Parity error while receiving packet\n");
 		return -1;
 	}
 
-	if (data_footer.rx_footer_bits.dv != DV_DATA_VALID) { /* No data to be received */
+	if (footer.rx_footer_bits.dv != DV_DATA_VALID) { /* No data to be received */
 		return 0;
 	}
 

--- a/samples/t1s/src/perf.c
+++ b/samples/t1s/src/perf.c
@@ -5,221 +5,239 @@
 #include "eth.h"
 #include "lan8651.h"
 
-static uint16_t make_perf_req_packet(uint8_t* packet, const uint8_t my_mac_addr[ETH_ALEN], const uint8_t target_mac_addr[ETH_ALEN], uint32_t duration, uint32_t warmup) {
-    struct ethhdr* eth = (struct ethhdr*)packet;
-    struct perf_startreq_header* startreq = (struct perf_startreq_header*)(eth + 1);
+static uint16_t make_perf_req_packet(uint8_t *packet, const uint8_t my_mac_addr[ETH_ALEN],
+				     const uint8_t target_mac_addr[ETH_ALEN], uint32_t duration,
+				     uint32_t warmup)
+{
+	struct ethhdr *eth = (struct ethhdr *)packet;
+	struct perf_startreq_header *startreq = (struct perf_startreq_header *)(eth + 1);
 
-    memcpy(eth->h_dest, target_mac_addr, ETH_ALEN);
-    memcpy(eth->h_source, my_mac_addr, ETH_ALEN);
-    eth->h_proto = sys_cpu_to_be16(PERF_ETHERTYPE);
+	memcpy(eth->h_dest, target_mac_addr, ETH_ALEN);
+	memcpy(eth->h_source, my_mac_addr, ETH_ALEN);
+	eth->h_proto = sys_cpu_to_be16(PERF_ETHERTYPE);
 
-    startreq->header.id = sys_cpu_to_be32(0xdeadbeef);
-    startreq->header.op = PERF_REQ_START;
+	startreq->header.id = sys_cpu_to_be32(0xdeadbeef);
+	startreq->header.op = PERF_REQ_START;
 
-    startreq->duration = sys_cpu_to_be32(duration);
-    startreq->warmup = sys_cpu_to_be32(warmup);
+	startreq->duration = sys_cpu_to_be32(duration);
+	startreq->warmup = sys_cpu_to_be32(warmup);
 
-    return sizeof(struct ethhdr) + sizeof(struct perf_startreq_header);
+	return sizeof(struct ethhdr) + sizeof(struct perf_startreq_header);
 }
 
-int send_perf_req_packet(const struct spi_dt_spec* spi, const uint8_t my_mac_addr[ETH_ALEN], const uint8_t target_mac_addr[ETH_ALEN], uint32_t duration, uint32_t warmup) {
-    uint8_t packet[HEADER_SIZE + MAX_PAYLOAD_BYTE] = {0};
-    uint16_t length = make_perf_req_packet(packet, my_mac_addr, target_mac_addr, duration, warmup);
+int send_perf_req_packet(const struct spi_dt_spec *spi, const uint8_t my_mac_addr[ETH_ALEN],
+			 const uint8_t target_mac_addr[ETH_ALEN], uint32_t duration,
+			 uint32_t warmup)
+{
+	uint8_t packet[HEADER_SIZE + MAX_PAYLOAD_BYTE] = {0};
+	uint16_t length =
+		make_perf_req_packet(packet, my_mac_addr, target_mac_addr, duration, warmup);
 
-    uint8_t txbuffer[HEADER_SIZE + MAX_PAYLOAD_BYTE] = {0};
-    uint8_t rxbuffer[MAX_PAYLOAD_BYTE + FOOTER_SIZE] = {0};
-    union data_header data_transfer_header;
+	uint8_t txbuffer[HEADER_SIZE + MAX_PAYLOAD_BYTE] = {0};
+	uint8_t rxbuffer[MAX_PAYLOAD_BYTE + FOOTER_SIZE] = {0};
+	union data_header data_transfer_header;
 
-    data_transfer_header.data_frame_head = 0;
-    uint32_t be_header;
+	data_transfer_header.data_frame_head = 0;
+	uint32_t be_header;
 
-    data_transfer_header.tx_header_bits.dnc = DNC_COMMANDTYPE_DATA;
-    data_transfer_header.tx_header_bits.norx = NORX_NO_RECEIVE;
-    data_transfer_header.tx_header_bits.dv = DV_DATA_VALID;
-    data_transfer_header.tx_header_bits.sv = SV_START_VALID;
-    data_transfer_header.tx_header_bits.ev = EV_END_VALID;
-    data_transfer_header.tx_header_bits.ebo = length - 1;
-    data_transfer_header.tx_header_bits.p = get_parity(data_transfer_header.data_frame_head);
+	data_transfer_header.tx_header_bits.dnc = DNC_COMMANDTYPE_DATA;
+	data_transfer_header.tx_header_bits.norx = NORX_NO_RECEIVE;
+	data_transfer_header.tx_header_bits.dv = DV_DATA_VALID;
+	data_transfer_header.tx_header_bits.sv = SV_START_VALID;
+	data_transfer_header.tx_header_bits.ev = EV_END_VALID;
+	data_transfer_header.tx_header_bits.ebo = length - 1;
+	data_transfer_header.tx_header_bits.p = get_parity(data_transfer_header.data_frame_head);
 
-    be_header = sys_cpu_to_be32(data_transfer_header.data_frame_head);
-    memcpy(txbuffer, &be_header, HEADER_SIZE);
+	be_header = sys_cpu_to_be32(data_transfer_header.data_frame_head);
+	memcpy(txbuffer, &be_header, HEADER_SIZE);
 
-    memcpy(&txbuffer[HEADER_SIZE], packet, length);
+	memcpy(&txbuffer[HEADER_SIZE], packet, length);
 
-    struct spi_buf tx_buf = {.buf = txbuffer, .len = HEADER_SIZE + MAX_PAYLOAD_BYTE};
-    const struct spi_buf_set tx_buf_set = {.buffers = &tx_buf, .count = 1};
+	struct spi_buf tx_buf = {.buf = txbuffer, .len = HEADER_SIZE + MAX_PAYLOAD_BYTE};
+	const struct spi_buf_set tx_buf_set = {.buffers = &tx_buf, .count = 1};
 	struct spi_buf rx_buf = {.buf = rxbuffer, .len = MAX_PAYLOAD_BYTE + FOOTER_SIZE};
 	const struct spi_buf_set rx_buf_set = {.buffers = &rx_buf, .count = 1};
-    spi_transceive_dt(spi, &tx_buf_set, &rx_buf_set);
+	spi_transceive_dt(spi, &tx_buf_set, &rx_buf_set);
 
-    return 0;
+	return 0;
 }
 
-uint16_t make_perf_data_packet(const uint8_t my_mac_addr[ETH_ALEN], const uint8_t target_mac_addr[ETH_ALEN], uint8_t* packet, uint32_t len) {
-    if (len < sizeof(struct ethhdr) + sizeof(struct perf_header)) {
-        printk("Length is too short: %u\n", len);
-        return 0;
-    }
+uint16_t make_perf_data_packet(const uint8_t my_mac_addr[ETH_ALEN],
+			       const uint8_t target_mac_addr[ETH_ALEN], uint8_t *packet,
+			       uint32_t len)
+{
+	if (len < sizeof(struct ethhdr) + sizeof(struct perf_header)) {
+		printk("Length is too short: %u\n", len);
+		return 0;
+	}
 
-    struct ethhdr* eth = (struct ethhdr*)packet;
-    struct perf_header* perf = (struct perf_header*)(eth + 1);
+	struct ethhdr *eth = (struct ethhdr *)packet;
+	struct perf_header *perf = (struct perf_header *)(eth + 1);
 
-    memcpy(eth->h_dest, target_mac_addr, ETH_ALEN);
-    memcpy(eth->h_source, my_mac_addr, ETH_ALEN);
-    eth->h_proto = sys_cpu_to_be16(PERF_ETHERTYPE);
+	memcpy(eth->h_dest, target_mac_addr, ETH_ALEN);
+	memcpy(eth->h_source, my_mac_addr, ETH_ALEN);
+	eth->h_proto = sys_cpu_to_be16(PERF_ETHERTYPE);
 
-    perf->id = sys_cpu_to_be32(0x0);
-    perf->op = PERF_DATA;
+	perf->id = sys_cpu_to_be32(0x0);
+	perf->op = PERF_DATA;
 
-    return len;
+	return len;
 }
 
-int send_perf_data_packet(const struct spi_dt_spec* spi, const uint8_t* packet, uint16_t length) {
-    if (length > MAX_PERF_PAYLOAD) {
-        printk("Length is too long\n");
-        return -1;
-    }
-    uint8_t txbuffer[HEADER_SIZE + MAX_PAYLOAD_BYTE] = {0};
-    uint8_t rxbuffer[MAX_PAYLOAD_BYTE + FOOTER_SIZE] = {0};
-    union data_header data_transfer_header;
+int send_perf_data_packet(const struct spi_dt_spec *spi, const uint8_t *packet, uint16_t length)
+{
+	if (length > MAX_PERF_PAYLOAD) {
+		printk("Length is too long\n");
+		return -1;
+	}
+	uint8_t txbuffer[HEADER_SIZE + MAX_PAYLOAD_BYTE] = {0};
+	uint8_t rxbuffer[MAX_PAYLOAD_BYTE + FOOTER_SIZE] = {0};
+	union data_header data_transfer_header;
 
-    data_transfer_header.data_frame_head = 0;
-    uint32_t be_header;
+	data_transfer_header.data_frame_head = 0;
+	uint32_t be_header;
 
-    uint32_t chunk_count = length / MAX_PAYLOAD_BYTE;
-    if (length % MAX_PAYLOAD_BYTE) {
-        chunk_count++;
-    }
+	uint32_t chunk_count = length / MAX_PAYLOAD_BYTE;
+	if (length % MAX_PAYLOAD_BYTE) {
+		chunk_count++;
+	}
 
-    uint32_t chunk_size = MAX_PAYLOAD_BYTE;
-    data_transfer_header.tx_header_bits.dnc = DNC_COMMANDTYPE_DATA;
-    data_transfer_header.tx_header_bits.norx = NORX_NO_RECEIVE;
-    data_transfer_header.tx_header_bits.dv = DV_DATA_VALID;
-    for (uint32_t i = 0; i < chunk_count; i++) {
-        data_transfer_header.tx_header_bits.sv = SV_START_INVALID;
-        data_transfer_header.tx_header_bits.ev = EV_END_INVALID;
-        data_transfer_header.tx_header_bits.ebo = 0;
+	uint32_t chunk_size = MAX_PAYLOAD_BYTE;
+	data_transfer_header.tx_header_bits.dnc = DNC_COMMANDTYPE_DATA;
+	data_transfer_header.tx_header_bits.norx = NORX_NO_RECEIVE;
+	data_transfer_header.tx_header_bits.dv = DV_DATA_VALID;
+	for (uint32_t i = 0; i < chunk_count; i++) {
+		data_transfer_header.tx_header_bits.sv = SV_START_INVALID;
+		data_transfer_header.tx_header_bits.ev = EV_END_INVALID;
+		data_transfer_header.tx_header_bits.ebo = 0;
 
-        if (i == 0) {  // First chunk
-            data_transfer_header.tx_header_bits.sv = SV_START_VALID;
-        } if (i == chunk_count - 1) {  // Last chunk
-            chunk_size = length % MAX_PAYLOAD_BYTE;
-            if (chunk_size == 0) {
-                chunk_size = MAX_PAYLOAD_BYTE;
-            }
-            data_transfer_header.tx_header_bits.ev = EV_END_VALID;
-            data_transfer_header.tx_header_bits.ebo = chunk_size - 1;
-        }
+		if (i == 0) { // First chunk
+			data_transfer_header.tx_header_bits.sv = SV_START_VALID;
+		}
+		if (i == chunk_count - 1) { // Last chunk
+			chunk_size = length % MAX_PAYLOAD_BYTE;
+			if (chunk_size == 0) {
+				chunk_size = MAX_PAYLOAD_BYTE;
+			}
+			data_transfer_header.tx_header_bits.ev = EV_END_VALID;
+			data_transfer_header.tx_header_bits.ebo = chunk_size - 1;
+		}
 
-        data_transfer_header.tx_header_bits.p = get_parity(data_transfer_header.data_frame_head);
+		data_transfer_header.tx_header_bits.p =
+			get_parity(data_transfer_header.data_frame_head);
 
-        be_header = sys_cpu_to_be32(data_transfer_header.data_frame_head);
-        memcpy(txbuffer, &be_header, HEADER_SIZE);
+		be_header = sys_cpu_to_be32(data_transfer_header.data_frame_head);
+		memcpy(txbuffer, &be_header, HEADER_SIZE);
 
-        memcpy(&txbuffer[HEADER_SIZE], packet + i * MAX_PAYLOAD_BYTE, MAX_PAYLOAD_BYTE);
+		memcpy(&txbuffer[HEADER_SIZE], packet + i * MAX_PAYLOAD_BYTE, MAX_PAYLOAD_BYTE);
 
-        struct spi_buf tx_buf = {.buf = txbuffer, .len = HEADER_SIZE + MAX_PAYLOAD_BYTE};
-        const struct spi_buf_set tx_buf_set = {.buffers = &tx_buf, .count = 1};
-        struct spi_buf rx_buf = {.buf = rxbuffer, .len = MAX_PAYLOAD_BYTE + FOOTER_SIZE};
-        const struct spi_buf_set rx_buf_set = {.buffers = &rx_buf, .count = 1};
-        spi_transceive_dt(spi, &tx_buf_set, &rx_buf_set);
-    }
+		struct spi_buf tx_buf = {.buf = txbuffer, .len = HEADER_SIZE + MAX_PAYLOAD_BYTE};
+		const struct spi_buf_set tx_buf_set = {.buffers = &tx_buf, .count = 1};
+		struct spi_buf rx_buf = {.buf = rxbuffer, .len = MAX_PAYLOAD_BYTE + FOOTER_SIZE};
+		const struct spi_buf_set rx_buf_set = {.buffers = &rx_buf, .count = 1};
+		spi_transceive_dt(spi, &tx_buf_set, &rx_buf_set);
+	}
 
-    return 0;
+	return 0;
 }
 
-int recv_latency_req(const struct spi_dt_spec* spi, uint8_t source_mac_addr[ETH_ALEN], uint32_t* id) {
-    uint8_t txbuffer[HEADER_SIZE + MAX_PAYLOAD_BYTE] = {0};
-    uint8_t rxbuffer[MAX_PAYLOAD_BYTE + FOOTER_SIZE] = {0};
+int recv_latency_req(const struct spi_dt_spec *spi, uint8_t source_mac_addr[ETH_ALEN], uint32_t *id)
+{
+	uint8_t txbuffer[HEADER_SIZE + MAX_PAYLOAD_BYTE] = {0};
+	uint8_t rxbuffer[MAX_PAYLOAD_BYTE + FOOTER_SIZE] = {0};
 
-    union data_header data_transfer_header;
+	union data_header data_transfer_header;
 
-    data_transfer_header.data_frame_head = 0;
-    uint32_t be_header;
-    data_transfer_header.tx_header_bits.dnc = DNC_COMMANDTYPE_DATA;
-    data_transfer_header.tx_header_bits.norx = NORX_RECEIVE;
-    data_transfer_header.tx_header_bits.dv = DV_DATA_INVALID;
-    data_transfer_header.tx_header_bits.sv = SV_START_INVALID;
-    data_transfer_header.tx_header_bits.ev = EV_END_INVALID;
-    data_transfer_header.tx_header_bits.ebo = 0;
+	data_transfer_header.data_frame_head = 0;
+	uint32_t be_header;
+	data_transfer_header.tx_header_bits.dnc = DNC_COMMANDTYPE_DATA;
+	data_transfer_header.tx_header_bits.norx = NORX_RECEIVE;
+	data_transfer_header.tx_header_bits.dv = DV_DATA_INVALID;
+	data_transfer_header.tx_header_bits.sv = SV_START_INVALID;
+	data_transfer_header.tx_header_bits.ev = EV_END_INVALID;
+	data_transfer_header.tx_header_bits.ebo = 0;
 
-    data_transfer_header.tx_header_bits.p = get_parity(data_transfer_header.data_frame_head);
+	data_transfer_header.tx_header_bits.p = get_parity(data_transfer_header.data_frame_head);
 
-    be_header = sys_cpu_to_be32(data_transfer_header.data_frame_head);
-    memcpy(txbuffer, &be_header, HEADER_SIZE);
+	be_header = sys_cpu_to_be32(data_transfer_header.data_frame_head);
+	memcpy(txbuffer, &be_header, HEADER_SIZE);
 
-    struct spi_buf tx_buf = {.buf = txbuffer, .len = HEADER_SIZE + MAX_PAYLOAD_BYTE};
-    const struct spi_buf_set tx_buf_set = {.buffers = &tx_buf, .count = 1};
-    struct spi_buf rx_buf = {.buf = rxbuffer, .len = MAX_PAYLOAD_BYTE + FOOTER_SIZE};
-    const struct spi_buf_set rx_buf_set = {.buffers = &rx_buf, .count = 1};
-    spi_transceive_dt(spi, &tx_buf_set, &rx_buf_set);
+	struct spi_buf tx_buf = {.buf = txbuffer, .len = HEADER_SIZE + MAX_PAYLOAD_BYTE};
+	const struct spi_buf_set tx_buf_set = {.buffers = &tx_buf, .count = 1};
+	struct spi_buf rx_buf = {.buf = rxbuffer, .len = MAX_PAYLOAD_BYTE + FOOTER_SIZE};
+	const struct spi_buf_set rx_buf_set = {.buffers = &rx_buf, .count = 1};
+	spi_transceive_dt(spi, &tx_buf_set, &rx_buf_set);
 
-    union data_footer data_footer;
-    data_footer.data_frame_foot = sys_be32_to_cpu(*(uint32_t*)(rxbuffer + MAX_PAYLOAD_BYTE));
-    if (data_footer.rx_footer_bits.p != get_parity(data_footer.data_frame_foot)) {
-        printk("Parity error while receiving packet\n");
-        return -1;
-    }
+	union data_footer data_footer;
+	data_footer.data_frame_foot = sys_be32_to_cpu(*(uint32_t *)(rxbuffer + MAX_PAYLOAD_BYTE));
+	if (data_footer.rx_footer_bits.p != get_parity(data_footer.data_frame_foot)) {
+		printk("Parity error while receiving packet\n");
+		return -1;
+	}
 
-    if (data_footer.rx_footer_bits.dv != DV_DATA_VALID) {  /* No data to be received */
-        return 0;
-    }
+	if (data_footer.rx_footer_bits.dv != DV_DATA_VALID) { /* No data to be received */
+		return 0;
+	}
 
-    memcpy(source_mac_addr, rxbuffer, ETH_ALEN);
-    struct ethhdr* eth = (struct ethhdr*)rxbuffer;
-    if (eth->h_proto != sys_cpu_to_be16(PERF_ETHERTYPE)) {  /* Ignore Non-Perf packets */
-        return 0;
-    }
+	memcpy(source_mac_addr, rxbuffer, ETH_ALEN);
+	struct ethhdr *eth = (struct ethhdr *)rxbuffer;
+	if (eth->h_proto != sys_cpu_to_be16(PERF_ETHERTYPE)) { /* Ignore Non-Perf packets */
+		return 0;
+	}
 
-    struct perf_latency_header* perf = (struct perf_latency_header*)(eth + 1);
-    *id = sys_be32_to_cpu(perf->id);
-    printk("Received latency request from %02x:%02x:%02x:%02x:%02x:%02x, id: %u\n",
-        source_mac_addr[0], source_mac_addr[1], source_mac_addr[2], source_mac_addr[3], source_mac_addr[4], source_mac_addr[5], *id);
+	struct perf_latency_header *perf = (struct perf_latency_header *)(eth + 1);
+	*id = sys_be32_to_cpu(perf->id);
+	printk("Received latency request from %02x:%02x:%02x:%02x:%02x:%02x, id: %u\n",
+	       source_mac_addr[0], source_mac_addr[1], source_mac_addr[2], source_mac_addr[3],
+	       source_mac_addr[4], source_mac_addr[5], *id);
 
-    return 0;
+	return 0;
 }
 
-uint16_t make_latency_res(uint8_t* packet, const uint8_t my_mac_addr[ETH_ALEN], const uint8_t target_mac_addr[ETH_ALEN], uint32_t id) {
-    struct ethhdr* eth = (struct ethhdr*)packet;
-    struct perf_latency_header* perf = (struct perf_latency_header*)(eth + 1);
+uint16_t make_latency_res(uint8_t *packet, const uint8_t my_mac_addr[ETH_ALEN],
+			  const uint8_t target_mac_addr[ETH_ALEN], uint32_t id)
+{
+	struct ethhdr *eth = (struct ethhdr *)packet;
+	struct perf_latency_header *perf = (struct perf_latency_header *)(eth + 1);
 
-    memcpy(eth->h_dest, target_mac_addr, ETH_ALEN);
-    memcpy(eth->h_source, my_mac_addr, ETH_ALEN);
-    eth->h_proto = sys_cpu_to_be16(PERF_ETHERTYPE);
+	memcpy(eth->h_dest, target_mac_addr, ETH_ALEN);
+	memcpy(eth->h_source, my_mac_addr, ETH_ALEN);
+	eth->h_proto = sys_cpu_to_be16(PERF_ETHERTYPE);
 
-    perf->id = sys_cpu_to_be32(id);
-    perf->op = PERF_RES_START;
+	perf->id = sys_cpu_to_be32(id);
+	perf->op = PERF_RES_START;
 
-    return sizeof(struct ethhdr) + sizeof(struct perf_latency_header);
+	return sizeof(struct ethhdr) + sizeof(struct perf_latency_header);
 }
 
-int send_latency_res(const struct spi_dt_spec* spi, const uint8_t* packet, uint16_t length) {
-    uint8_t txbuffer[HEADER_SIZE + MAX_PAYLOAD_BYTE] = {0};
-    uint8_t rxbuffer[MAX_PAYLOAD_BYTE + FOOTER_SIZE] = {0};
+int send_latency_res(const struct spi_dt_spec *spi, const uint8_t *packet, uint16_t length)
+{
+	uint8_t txbuffer[HEADER_SIZE + MAX_PAYLOAD_BYTE] = {0};
+	uint8_t rxbuffer[MAX_PAYLOAD_BYTE + FOOTER_SIZE] = {0};
 
-    union data_header data_transfer_header;
+	union data_header data_transfer_header;
 
-    data_transfer_header.data_frame_head = 0;
-    uint32_t be_header;
-    data_transfer_header.tx_header_bits.dnc = DNC_COMMANDTYPE_DATA;
-    data_transfer_header.tx_header_bits.norx = NORX_NO_RECEIVE;
-    data_transfer_header.tx_header_bits.dv = DV_DATA_VALID;
-    data_transfer_header.tx_header_bits.sv = SV_START_VALID;
-    data_transfer_header.tx_header_bits.ev = EV_END_VALID;
-    data_transfer_header.tx_header_bits.ebo = 0;
+	data_transfer_header.data_frame_head = 0;
+	uint32_t be_header;
+	data_transfer_header.tx_header_bits.dnc = DNC_COMMANDTYPE_DATA;
+	data_transfer_header.tx_header_bits.norx = NORX_NO_RECEIVE;
+	data_transfer_header.tx_header_bits.dv = DV_DATA_VALID;
+	data_transfer_header.tx_header_bits.sv = SV_START_VALID;
+	data_transfer_header.tx_header_bits.ev = EV_END_VALID;
+	data_transfer_header.tx_header_bits.ebo = 0;
 
-    data_transfer_header.tx_header_bits.p = get_parity(data_transfer_header.data_frame_head);
+	data_transfer_header.tx_header_bits.p = get_parity(data_transfer_header.data_frame_head);
 
-    be_header = sys_cpu_to_be32(data_transfer_header.data_frame_head);
-    memcpy(txbuffer, &be_header, HEADER_SIZE);
+	be_header = sys_cpu_to_be32(data_transfer_header.data_frame_head);
+	memcpy(txbuffer, &be_header, HEADER_SIZE);
 
-    memcpy(&txbuffer[HEADER_SIZE], packet, length);
+	memcpy(&txbuffer[HEADER_SIZE], packet, length);
 
-    struct spi_buf tx_buf = {.buf = txbuffer, .len = HEADER_SIZE + MAX_PAYLOAD_BYTE};
-    const struct spi_buf_set tx_buf_set = {.buffers = &tx_buf, .count = 1};
-    struct spi_buf rx_buf = {.buf = rxbuffer, .len = MAX_PAYLOAD_BYTE + FOOTER_SIZE};
-    const struct spi_buf_set rx_buf_set = {.buffers = &rx_buf, .count = 1};
-    spi_transceive_dt(spi, &tx_buf_set, &rx_buf_set);
+	struct spi_buf tx_buf = {.buf = txbuffer, .len = HEADER_SIZE + MAX_PAYLOAD_BYTE};
+	const struct spi_buf_set tx_buf_set = {.buffers = &tx_buf, .count = 1};
+	struct spi_buf rx_buf = {.buf = rxbuffer, .len = MAX_PAYLOAD_BYTE + FOOTER_SIZE};
+	const struct spi_buf_set rx_buf_set = {.buffers = &rx_buf, .count = 1};
+	spi_transceive_dt(spi, &tx_buf_set, &rx_buf_set);
 
-    return 0;
+	return 0;
 }

--- a/samples/t1s/src/perf.c
+++ b/samples/t1s/src/perf.c
@@ -1,0 +1,225 @@
+#include <zephyr/sys/byteorder.h>
+#include <zephyr/sys/printk.h>
+
+#include "perf.h"
+#include "eth.h"
+#include "lan8651.h"
+
+static uint16_t make_perf_req_packet(uint8_t* packet, const uint8_t my_mac_addr[ETH_ALEN], const uint8_t target_mac_addr[ETH_ALEN], uint32_t duration, uint32_t warmup) {
+    struct ethhdr* eth = (struct ethhdr*)packet;
+    struct perf_startreq_header* startreq = (struct perf_startreq_header*)(eth + 1);
+
+    memcpy(eth->h_dest, target_mac_addr, ETH_ALEN);
+    memcpy(eth->h_source, my_mac_addr, ETH_ALEN);
+    eth->h_proto = sys_cpu_to_be16(PERF_ETHERTYPE);
+
+    startreq->header.id = sys_cpu_to_be32(0xdeadbeef);
+    startreq->header.op = PERF_REQ_START;
+
+    startreq->duration = sys_cpu_to_be32(duration);
+    startreq->warmup = sys_cpu_to_be32(warmup);
+
+    return sizeof(struct ethhdr) + sizeof(struct perf_startreq_header);
+}
+
+int send_perf_req_packet(const struct spi_dt_spec* spi, const uint8_t my_mac_addr[ETH_ALEN], const uint8_t target_mac_addr[ETH_ALEN], uint32_t duration, uint32_t warmup) {
+    uint8_t packet[HEADER_SIZE + MAX_PAYLOAD_BYTE] = {0};
+    uint16_t length = make_perf_req_packet(packet, my_mac_addr, target_mac_addr, duration, warmup);
+
+    uint8_t txbuffer[HEADER_SIZE + MAX_PAYLOAD_BYTE] = {0};
+    uint8_t rxbuffer[MAX_PAYLOAD_BYTE + FOOTER_SIZE] = {0};
+    union data_header data_transfer_header;
+
+    data_transfer_header.data_frame_head = 0;
+    uint32_t be_header;
+
+    data_transfer_header.tx_header_bits.dnc = DNC_COMMANDTYPE_DATA;
+    data_transfer_header.tx_header_bits.norx = NORX_NO_RECEIVE;
+    data_transfer_header.tx_header_bits.dv = DV_DATA_VALID;
+    data_transfer_header.tx_header_bits.sv = SV_START_VALID;
+    data_transfer_header.tx_header_bits.ev = EV_END_VALID;
+    data_transfer_header.tx_header_bits.ebo = length - 1;
+    data_transfer_header.tx_header_bits.p = get_parity(data_transfer_header.data_frame_head);
+
+    be_header = sys_cpu_to_be32(data_transfer_header.data_frame_head);
+    memcpy(txbuffer, &be_header, HEADER_SIZE);
+
+    memcpy(&txbuffer[HEADER_SIZE], packet, length);
+
+    struct spi_buf tx_buf = {.buf = txbuffer, .len = HEADER_SIZE + MAX_PAYLOAD_BYTE};
+    const struct spi_buf_set tx_buf_set = {.buffers = &tx_buf, .count = 1};
+	struct spi_buf rx_buf = {.buf = rxbuffer, .len = MAX_PAYLOAD_BYTE + FOOTER_SIZE};
+	const struct spi_buf_set rx_buf_set = {.buffers = &rx_buf, .count = 1};
+    spi_transceive_dt(spi, &tx_buf_set, &rx_buf_set);
+
+    return 0;
+}
+
+uint16_t make_perf_data_packet(const uint8_t my_mac_addr[ETH_ALEN], const uint8_t target_mac_addr[ETH_ALEN], uint8_t* packet, uint32_t len) {
+    if (len < sizeof(struct ethhdr) + sizeof(struct perf_header)) {
+        printk("Length is too short: %u\n", len);
+        return 0;
+    }
+
+    struct ethhdr* eth = (struct ethhdr*)packet;
+    struct perf_header* perf = (struct perf_header*)(eth + 1);
+
+    memcpy(eth->h_dest, target_mac_addr, ETH_ALEN);
+    memcpy(eth->h_source, my_mac_addr, ETH_ALEN);
+    eth->h_proto = sys_cpu_to_be16(PERF_ETHERTYPE);
+
+    perf->id = sys_cpu_to_be32(0x0);
+    perf->op = PERF_DATA;
+
+    return len;
+}
+
+int send_perf_data_packet(const struct spi_dt_spec* spi, const uint8_t* packet, uint16_t length) {
+    if (length > MAX_PERF_PAYLOAD) {
+        printk("Length is too long\n");
+        return -1;
+    }
+    uint8_t txbuffer[HEADER_SIZE + MAX_PAYLOAD_BYTE] = {0};
+    uint8_t rxbuffer[MAX_PAYLOAD_BYTE + FOOTER_SIZE] = {0};
+    union data_header data_transfer_header;
+
+    data_transfer_header.data_frame_head = 0;
+    uint32_t be_header;
+
+    uint32_t chunk_count = length / MAX_PAYLOAD_BYTE;
+    if (length % MAX_PAYLOAD_BYTE) {
+        chunk_count++;
+    }
+
+    uint32_t chunk_size = MAX_PAYLOAD_BYTE;
+    data_transfer_header.tx_header_bits.dnc = DNC_COMMANDTYPE_DATA;
+    data_transfer_header.tx_header_bits.norx = NORX_NO_RECEIVE;
+    data_transfer_header.tx_header_bits.dv = DV_DATA_VALID;
+    for (uint32_t i = 0; i < chunk_count; i++) {
+        data_transfer_header.tx_header_bits.sv = SV_START_INVALID;
+        data_transfer_header.tx_header_bits.ev = EV_END_INVALID;
+        data_transfer_header.tx_header_bits.ebo = 0;
+
+        if (i == 0) {  // First chunk
+            data_transfer_header.tx_header_bits.sv = SV_START_VALID;
+        } if (i == chunk_count - 1) {  // Last chunk
+            chunk_size = length % MAX_PAYLOAD_BYTE;
+            if (chunk_size == 0) {
+                chunk_size = MAX_PAYLOAD_BYTE;
+            }
+            data_transfer_header.tx_header_bits.ev = EV_END_VALID;
+            data_transfer_header.tx_header_bits.ebo = chunk_size - 1;
+        }
+
+        data_transfer_header.tx_header_bits.p = get_parity(data_transfer_header.data_frame_head);
+
+        be_header = sys_cpu_to_be32(data_transfer_header.data_frame_head);
+        memcpy(txbuffer, &be_header, HEADER_SIZE);
+
+        memcpy(&txbuffer[HEADER_SIZE], packet + i * MAX_PAYLOAD_BYTE, MAX_PAYLOAD_BYTE);
+
+        struct spi_buf tx_buf = {.buf = txbuffer, .len = HEADER_SIZE + MAX_PAYLOAD_BYTE};
+        const struct spi_buf_set tx_buf_set = {.buffers = &tx_buf, .count = 1};
+        struct spi_buf rx_buf = {.buf = rxbuffer, .len = MAX_PAYLOAD_BYTE + FOOTER_SIZE};
+        const struct spi_buf_set rx_buf_set = {.buffers = &rx_buf, .count = 1};
+        spi_transceive_dt(spi, &tx_buf_set, &rx_buf_set);
+    }
+
+    return 0;
+}
+
+int recv_latency_req(const struct spi_dt_spec* spi, uint8_t source_mac_addr[ETH_ALEN], uint32_t* id) {
+    uint8_t txbuffer[HEADER_SIZE + MAX_PAYLOAD_BYTE] = {0};
+    uint8_t rxbuffer[MAX_PAYLOAD_BYTE + FOOTER_SIZE] = {0};
+
+    union data_header data_transfer_header;
+
+    data_transfer_header.data_frame_head = 0;
+    uint32_t be_header;
+    data_transfer_header.tx_header_bits.dnc = DNC_COMMANDTYPE_DATA;
+    data_transfer_header.tx_header_bits.norx = NORX_RECEIVE;
+    data_transfer_header.tx_header_bits.dv = DV_DATA_INVALID;
+    data_transfer_header.tx_header_bits.sv = SV_START_INVALID;
+    data_transfer_header.tx_header_bits.ev = EV_END_INVALID;
+    data_transfer_header.tx_header_bits.ebo = 0;
+
+    data_transfer_header.tx_header_bits.p = get_parity(data_transfer_header.data_frame_head);
+
+    be_header = sys_cpu_to_be32(data_transfer_header.data_frame_head);
+    memcpy(txbuffer, &be_header, HEADER_SIZE);
+
+    struct spi_buf tx_buf = {.buf = txbuffer, .len = HEADER_SIZE + MAX_PAYLOAD_BYTE};
+    const struct spi_buf_set tx_buf_set = {.buffers = &tx_buf, .count = 1};
+    struct spi_buf rx_buf = {.buf = rxbuffer, .len = MAX_PAYLOAD_BYTE + FOOTER_SIZE};
+    const struct spi_buf_set rx_buf_set = {.buffers = &rx_buf, .count = 1};
+    spi_transceive_dt(spi, &tx_buf_set, &rx_buf_set);
+
+    union data_footer data_footer;
+    data_footer.data_frame_foot = sys_be32_to_cpu(*(uint32_t*)(rxbuffer + MAX_PAYLOAD_BYTE));
+    if (data_footer.rx_footer_bits.p != get_parity(data_footer.data_frame_foot)) {
+        printk("Parity error while receiving packet\n");
+        return -1;
+    }
+
+    if (data_footer.rx_footer_bits.dv != DV_DATA_VALID) {  /* No data to be received */
+        return 0;
+    }
+
+    memcpy(source_mac_addr, rxbuffer, ETH_ALEN);
+    struct ethhdr* eth = (struct ethhdr*)rxbuffer;
+    if (eth->h_proto != sys_cpu_to_be16(PERF_ETHERTYPE)) {  /* Ignore Non-Perf packets */
+        return 0;
+    }
+
+    struct perf_latency_header* perf = (struct perf_latency_header*)(eth + 1);
+    *id = sys_be32_to_cpu(perf->id);
+    printk("Received latency request from %02x:%02x:%02x:%02x:%02x:%02x, id: %u\n",
+        source_mac_addr[0], source_mac_addr[1], source_mac_addr[2], source_mac_addr[3], source_mac_addr[4], source_mac_addr[5], *id);
+
+    return 0;
+}
+
+uint16_t make_latency_res(uint8_t* packet, const uint8_t my_mac_addr[ETH_ALEN], const uint8_t target_mac_addr[ETH_ALEN], uint32_t id) {
+    struct ethhdr* eth = (struct ethhdr*)packet;
+    struct perf_latency_header* perf = (struct perf_latency_header*)(eth + 1);
+
+    memcpy(eth->h_dest, target_mac_addr, ETH_ALEN);
+    memcpy(eth->h_source, my_mac_addr, ETH_ALEN);
+    eth->h_proto = sys_cpu_to_be16(PERF_ETHERTYPE);
+
+    perf->id = sys_cpu_to_be32(id);
+    perf->op = PERF_RES_START;
+
+    return sizeof(struct ethhdr) + sizeof(struct perf_latency_header);
+}
+
+int send_latency_res(const struct spi_dt_spec* spi, const uint8_t* packet, uint16_t length) {
+    uint8_t txbuffer[HEADER_SIZE + MAX_PAYLOAD_BYTE] = {0};
+    uint8_t rxbuffer[MAX_PAYLOAD_BYTE + FOOTER_SIZE] = {0};
+
+    union data_header data_transfer_header;
+
+    data_transfer_header.data_frame_head = 0;
+    uint32_t be_header;
+    data_transfer_header.tx_header_bits.dnc = DNC_COMMANDTYPE_DATA;
+    data_transfer_header.tx_header_bits.norx = NORX_NO_RECEIVE;
+    data_transfer_header.tx_header_bits.dv = DV_DATA_VALID;
+    data_transfer_header.tx_header_bits.sv = SV_START_VALID;
+    data_transfer_header.tx_header_bits.ev = EV_END_VALID;
+    data_transfer_header.tx_header_bits.ebo = 0;
+
+    data_transfer_header.tx_header_bits.p = get_parity(data_transfer_header.data_frame_head);
+
+    be_header = sys_cpu_to_be32(data_transfer_header.data_frame_head);
+    memcpy(txbuffer, &be_header, HEADER_SIZE);
+
+    memcpy(&txbuffer[HEADER_SIZE], packet, length);
+
+    struct spi_buf tx_buf = {.buf = txbuffer, .len = HEADER_SIZE + MAX_PAYLOAD_BYTE};
+    const struct spi_buf_set tx_buf_set = {.buffers = &tx_buf, .count = 1};
+    struct spi_buf rx_buf = {.buf = rxbuffer, .len = MAX_PAYLOAD_BYTE + FOOTER_SIZE};
+    const struct spi_buf_set rx_buf_set = {.buffers = &rx_buf, .count = 1};
+    spi_transceive_dt(spi, &tx_buf_set, &rx_buf_set);
+
+    return 0;
+}

--- a/samples/t1s/src/perf.h
+++ b/samples/t1s/src/perf.h
@@ -1,0 +1,48 @@
+#ifndef PERF_H
+#define PERF_H
+
+#include <stdint.h>
+#include <zephyr/drivers/spi.h>
+
+#include "eth.h"
+
+struct perf_header {
+    uint32_t id;
+    uint8_t op;
+} __attribute__((packed));
+
+struct perf_startreq_header {
+    struct perf_header header;
+    uint32_t duration; 
+    uint32_t warmup; 
+} __attribute__((packed));
+
+struct perf_latency_header {
+    uint32_t id;
+    uint8_t op;
+    uint32_t tv_sec;
+    uint32_t tv_usec;
+} __attribute__((packed));
+
+enum perf_op {
+    PERF_REQ_START = 0x00,
+    PERF_REQ_END = 0x01,
+    PERF_RES_START = 0x20,
+    PERF_RES_END = 0x21,
+    PERF_DATA = 0x30,
+    PERF_REQ_RESULT = 0x40,
+    PERF_RES_RESULT = 0x41,
+};
+
+#define PERF_ETHERTYPE 0x1337
+#define MAX_PERF_PAYLOAD 1500
+
+int send_perf_req_packet(const struct spi_dt_spec* spi, const uint8_t my_mac_addr[ETH_ALEN], const uint8_t target_mac_addr[ETH_ALEN], uint32_t duration, uint32_t warmup);
+uint16_t make_perf_data_packet(const uint8_t my_mac_addr[ETH_ALEN], const uint8_t target_mac_addr[ETH_ALEN], uint8_t* packet, uint32_t len);
+int send_perf_data_packet(const struct spi_dt_spec* spi, const uint8_t* packet, uint16_t length);
+
+int recv_latency_req(const struct spi_dt_spec* spi, uint8_t source_mac_addr[ETH_ALEN], uint32_t* id);
+uint16_t make_latency_res(uint8_t* packet, const uint8_t my_mac_addr[ETH_ALEN], const uint8_t target_mac_addr[ETH_ALEN], uint32_t id);
+int send_latency_res(const struct spi_dt_spec* spi, const uint8_t* packet, uint16_t length);
+
+#endif /* PERF_H */

--- a/samples/t1s/src/perf.h
+++ b/samples/t1s/src/perf.h
@@ -7,42 +7,48 @@
 #include "eth.h"
 
 struct perf_header {
-    uint32_t id;
-    uint8_t op;
+	uint32_t id;
+	uint8_t op;
 } __attribute__((packed));
 
 struct perf_startreq_header {
-    struct perf_header header;
-    uint32_t duration; 
-    uint32_t warmup; 
+	struct perf_header header;
+	uint32_t duration;
+	uint32_t warmup;
 } __attribute__((packed));
 
 struct perf_latency_header {
-    uint32_t id;
-    uint8_t op;
-    uint32_t tv_sec;
-    uint32_t tv_usec;
+	uint32_t id;
+	uint8_t op;
+	uint32_t tv_sec;
+	uint32_t tv_usec;
 } __attribute__((packed));
 
 enum perf_op {
-    PERF_REQ_START = 0x00,
-    PERF_REQ_END = 0x01,
-    PERF_RES_START = 0x20,
-    PERF_RES_END = 0x21,
-    PERF_DATA = 0x30,
-    PERF_REQ_RESULT = 0x40,
-    PERF_RES_RESULT = 0x41,
+	PERF_REQ_START = 0x00,
+	PERF_REQ_END = 0x01,
+	PERF_RES_START = 0x20,
+	PERF_RES_END = 0x21,
+	PERF_DATA = 0x30,
+	PERF_REQ_RESULT = 0x40,
+	PERF_RES_RESULT = 0x41,
 };
 
-#define PERF_ETHERTYPE 0x1337
+#define PERF_ETHERTYPE   0x1337
 #define MAX_PERF_PAYLOAD 1500
 
-int send_perf_req_packet(const struct spi_dt_spec* spi, const uint8_t my_mac_addr[ETH_ALEN], const uint8_t target_mac_addr[ETH_ALEN], uint32_t duration, uint32_t warmup);
-uint16_t make_perf_data_packet(const uint8_t my_mac_addr[ETH_ALEN], const uint8_t target_mac_addr[ETH_ALEN], uint8_t* packet, uint32_t len);
-int send_perf_data_packet(const struct spi_dt_spec* spi, const uint8_t* packet, uint16_t length);
+int send_perf_req_packet(const struct spi_dt_spec *spi, const uint8_t my_mac_addr[ETH_ALEN],
+			 const uint8_t target_mac_addr[ETH_ALEN], uint32_t duration,
+			 uint32_t warmup);
+uint16_t make_perf_data_packet(const uint8_t my_mac_addr[ETH_ALEN],
+			       const uint8_t target_mac_addr[ETH_ALEN], uint8_t *packet,
+			       uint32_t len);
+int send_perf_data_packet(const struct spi_dt_spec *spi, const uint8_t *packet, uint16_t length);
 
-int recv_latency_req(const struct spi_dt_spec* spi, uint8_t source_mac_addr[ETH_ALEN], uint32_t* id);
-uint16_t make_latency_res(uint8_t* packet, const uint8_t my_mac_addr[ETH_ALEN], const uint8_t target_mac_addr[ETH_ALEN], uint32_t id);
-int send_latency_res(const struct spi_dt_spec* spi, const uint8_t* packet, uint16_t length);
+int recv_latency_req(const struct spi_dt_spec *spi, uint8_t source_mac_addr[ETH_ALEN],
+		     uint32_t *id);
+uint16_t make_latency_res(uint8_t *packet, const uint8_t my_mac_addr[ETH_ALEN],
+			  const uint8_t target_mac_addr[ETH_ALEN], uint32_t id);
+int send_latency_res(const struct spi_dt_spec *spi, const uint8_t *packet, uint16_t length);
 
 #endif /* PERF_H */

--- a/samples/t1s/src/perf.h
+++ b/samples/t1s/src/perf.h
@@ -24,7 +24,7 @@ struct perf_latency_header {
 	uint32_t tv_usec;
 } __attribute__((packed));
 
-enum perf_op {
+enum perf_throughput_op {
 	PERF_REQ_START = 0x00,
 	PERF_REQ_END = 0x01,
 	PERF_RES_START = 0x20,
@@ -32,6 +32,13 @@ enum perf_op {
 	PERF_DATA = 0x30,
 	PERF_REQ_RESULT = 0x40,
 	PERF_RES_RESULT = 0x41,
+};
+
+enum perf_latency_op {
+	PERF_PING = 0,
+	PERF_PONG = 1,
+	PERF_TX = 2,
+	PERF_SYNC = 3,
 };
 
 #define PERF_ETHERTYPE   0x1337

--- a/samples/t1s/src/spi.c
+++ b/samples/t1s/src/spi.c
@@ -5,44 +5,48 @@
 
 #include "spi.h"
 
-static inline void get_ths(uint32_t* wth, uint32_t* rth) {
-    uint32_t status = sys_read32(SPI_STAT(SPI_BASE));
-    *wth = (status & (0x1 << 1)) >> 1;
-    *rth = (status & (0x1 << 0)) >> 0;
+static inline void get_ths(uint32_t *wth, uint32_t *rth)
+{
+	uint32_t status = sys_read32(SPI_STAT(SPI_BASE));
+	*wth = (status & (0x1 << 1)) >> 1;
+	*rth = (status & (0x1 << 0)) >> 0;
 }
 
-int transceive(uint8_t* tx_buf, uint8_t* rx_buf, uint32_t length) {
-    if (tx_buf == NULL || rx_buf == NULL || length == 0) {
-        return -1;
-    }
+int transceive(uint8_t *tx_buf, uint8_t *rx_buf, uint32_t length)
+{
+	if (tx_buf == NULL || rx_buf == NULL || length == 0) {
+		return -1;
+	}
 
-    uint32_t tx_offset = 0, rx_offset = 0;
-    uint32_t wth, rth;
-    uint32_t spi_data;
-    get_ths(&wth, &rth);
-    while (tx_offset < length || rx_offset < length) {
-        if (tx_offset < length && wth != 0) {
-            spi_data = sys_get_be32(&tx_buf[tx_offset]);
-            sys_write32(spi_data, SPI_DATA(SPI_BASE));
-            tx_offset += SPI_WORD_BYTES;
-        }
-        if (rx_offset < length && rth != 0) {
-            spi_data = sys_read32(SPI_DATA(SPI_BASE));
-            sys_put_be32(spi_data, &rx_buf[rx_offset]);
-            rx_offset += SPI_WORD_BYTES;
-        }
+	uint32_t tx_offset = 0, rx_offset = 0;
+	uint32_t wth, rth;
+	uint32_t spi_data;
+	get_ths(&wth, &rth);
+	while (tx_offset < length || rx_offset < length) {
+		if (tx_offset < length && wth != 0) {
+			spi_data = sys_get_be32(&tx_buf[tx_offset]);
+			sys_write32(spi_data, SPI_DATA(SPI_BASE));
+			tx_offset += SPI_WORD_BYTES;
+		}
+		if (rx_offset < length && rth != 0) {
+			spi_data = sys_read32(SPI_DATA(SPI_BASE));
+			sys_put_be32(spi_data, &rx_buf[rx_offset]);
+			rx_offset += SPI_WORD_BYTES;
+		}
 
-        get_ths(&wth, &rth);
-    }
+		get_ths(&wth, &rth);
+	}
 
-    return 0;
+	return 0;
 }
 
-void setup_dma() {
+void setup_dma()
+{
 	/* Configure DMA settings */
-	sys_write32(0, SPI_DMA_CTRL(SPI_BASE));  /* Clear everything */
-	sys_write32(SPI_INTEN_DW | SPI_INTEN_DR, SPI_INTEN(SPI_BASE));  /* TODO: This might be unnecessary */
-	sys_write32(SPI_DMA_CTR_PCLR, SPI_DMA_CTRL(SPI_BASE));  /* Clear state bits */
+	sys_write32(0, SPI_DMA_CTRL(SPI_BASE)); /* Clear everything */
+	sys_write32(SPI_INTEN_DW | SPI_INTEN_DR,
+		    SPI_INTEN(SPI_BASE));                      /* TODO: This might be unnecessary */
+	sys_write32(SPI_DMA_CTR_PCLR, SPI_DMA_CTRL(SPI_BASE)); /* Clear state bits */
 
 	uint32_t dma_icr = sys_read32(SPI_DMA_ICR(SPI_BASE));
 	dma_icr |= SPI_DMA_ICR_IED;

--- a/samples/t1s/src/spi.c
+++ b/samples/t1s/src/spi.c
@@ -1,0 +1,50 @@
+#include <zephyr/sys/printk.h>
+#include <zephyr/sys/byteorder.h>
+#include <zephyr/arch/common/sys_io.h>
+#include <zephyr/arch/arm64/misc.h>
+
+#include "spi.h"
+
+static inline void get_ths(uint32_t* wth, uint32_t* rth) {
+    uint32_t status = sys_read32(SPI_STAT(SPI_BASE));
+    *wth = (status & (0x1 << 1)) >> 1;
+    *rth = (status & (0x1 << 0)) >> 0;
+}
+
+int transceive(uint8_t* tx_buf, uint8_t* rx_buf, uint32_t length) {
+    if (tx_buf == NULL || rx_buf == NULL || length == 0) {
+        return -1;
+    }
+
+    uint32_t tx_offset = 0, rx_offset = 0;
+    uint32_t wth, rth;
+    uint32_t spi_data;
+    get_ths(&wth, &rth);
+    while (tx_offset < length || rx_offset < length) {
+        if (tx_offset < length && wth != 0) {
+            spi_data = sys_get_be32(&tx_buf[tx_offset]);
+            sys_write32(spi_data, SPI_DATA(SPI_BASE));
+            tx_offset += SPI_WORD_BYTES;
+        }
+        if (rx_offset < length && rth != 0) {
+            spi_data = sys_read32(SPI_DATA(SPI_BASE));
+            sys_put_be32(spi_data, &rx_buf[rx_offset]);
+            rx_offset += SPI_WORD_BYTES;
+        }
+
+        get_ths(&wth, &rth);
+    }
+
+    return 0;
+}
+
+void setup_dma() {
+	/* Configure DMA settings */
+	sys_write32(0, SPI_DMA_CTRL(SPI_BASE));  /* Clear everything */
+	sys_write32(SPI_INTEN_DW | SPI_INTEN_DR, SPI_INTEN(SPI_BASE));  /* TODO: This might be unnecessary */
+	sys_write32(SPI_DMA_CTR_PCLR, SPI_DMA_CTRL(SPI_BASE));  /* Clear state bits */
+
+	uint32_t dma_icr = sys_read32(SPI_DMA_ICR(SPI_BASE));
+	dma_icr |= SPI_DMA_ICR_IED;
+	sys_write32(dma_icr, SPI_DMA_ICR(SPI_BASE));
+}

--- a/samples/t1s/src/spi.h
+++ b/samples/t1s/src/spi.h
@@ -1,0 +1,40 @@
+#ifndef SPI_H
+#define SPI_H
+
+#include <stdint.h>
+
+#include <zephyr/sys/printk.h>
+#include <zephyr/sys/byteorder.h>
+
+#define SPI_BASE 0xA0100000
+
+#define SPI_DATA(base)       (base + 0x00)
+#define SPI_STAT(base)       (base + 0x04)
+#define SPI_INTEN(base)      (base + 0x08)
+#define SPI_MODE(base)       (base + 0x0c)
+#define SPI_CTRL(base)       (base + 0x10)
+#define SPI_EVTCTRL(base)    (base + 0x14)
+#define SPI_DMA_CTRL(base)   (base + 0x2c)
+#define SPI_DMA_STATUS(base) (base + 0x30)
+#define SPI_TXBASE(base)     (base + 0x20)
+#define SPI_RXBASE(base)     (base + 0x24)
+#define SPI_PACKET(base)     (base + 0x28)
+#define SPI_DMA_ICR(base)    (base + 0x34)
+
+#define SPI_INTEN_DR BIT(30)
+#define SPI_INTEN_DW BIT(31)
+
+#define SPI_DMA_CTR_EN   BIT(0)
+#define SPI_DMA_CTR_PCLR BIT(2)
+#define SPI_DMA_CTR_DRE  BIT(30)
+#define SPI_DMA_CTR_DTE  BIT(31)
+
+#define SPI_DMA_ICR_IED BIT(17)
+#define SPI_DMA_ICR_ISD BIT(29)
+
+#define SPI_WORD_BYTES 4
+
+int transceive(uint8_t* tx_buf, uint8_t* rx_buf, uint32_t length);
+void setup_dma();
+
+#endif /* SPI_H */

--- a/samples/t1s/src/spi.h
+++ b/samples/t1s/src/spi.h
@@ -34,7 +34,7 @@
 
 #define SPI_WORD_BYTES 4
 
-int transceive(uint8_t* tx_buf, uint8_t* rx_buf, uint32_t length);
+int transceive(uint8_t *tx_buf, uint8_t *rx_buf, uint32_t length);
 void setup_dma();
 
 #endif /* SPI_H */


### PR DESCRIPTION
LAN8651의 드라이버와 같이 사용할 수 있는 코드를 sample로 추가하였으며, SPI 드라이버가 DMA를 사용하도록 했습니다.

또한, 그것을 사용하는 arping, throughput(client만), latency(server만) 예제를 추가하였습니다.

closing: sw-1488, sw-1489. sw-1510, sw-1511, sw-1510, sw-1511